### PR TITLE
feat: transform UMLS client core SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install package and dev dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev]"
+          python -m pip install ".[dev,docs]"
 
       - name: Ruff lint
         run: ruff check .
@@ -37,6 +37,9 @@ jobs:
 
       - name: Tests
         run: pytest
+
+      - name: Docs
+        run: mkdocs build --strict
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: "Existing or new tag to publish, for example v1.1.0"
+        description: "Existing or new tag to publish, for example v1.2.0"
         required: true
-        default: "v1.1.0"
+        default: "v1.2.0"
 
 permissions:
   contents: write
@@ -58,7 +58,7 @@ jobs:
       - name: Install package and dev dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev]"
+          python -m pip install ".[dev,docs]"
 
       - name: Ruff lint
         run: ruff check .
@@ -71,6 +71,9 @@ jobs:
 
       - name: Tests
         run: pytest
+
+      - name: Docs
+        run: mkdocs build --strict
 
       - name: Build package
         run: python -m build
@@ -176,7 +179,7 @@ jobs:
       - name: Install package and dev dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev]"
+          python -m pip install ".[dev,docs]"
 
       - name: Ruff lint
         run: ruff check .
@@ -189,6 +192,9 @@ jobs:
 
       - name: Tests
         run: pytest
+
+      - name: Docs
+        run: mkdocs build --strict
 
       - name: Build package
         run: python -m build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .mypy_cache/
 .coverage
 htmlcov/
+site/
 
 # Builds
 build/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include LICENSE
 include README.md
+include mkdocs.yml
 include pyproject.toml
+recursive-include docs *.md
 recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -1,9 +1,26 @@
 # UMLS Python Client
 
-Production-ready Python client for the NLM UMLS REST APIs.
+Production-ready Python SDK for the National Library of Medicine UMLS
+Terminology Services APIs.
 
-The package keeps the original `UMLSClient` behavior for existing users and adds
-typed sync and async clients for new applications.
+`umls-python-client` keeps the original `UMLSClient` interface for existing
+users and adds typed sync, async, export, release, and workflow helpers for new
+applications. It is designed for developers and researchers who need a practical
+one-stop Python client for UMLS search, concepts, source vocabularies, semantic
+types, crosswalks, metadata, and UTS release downloads.
+
+## Why This Client
+
+- Current NLM REST coverage, including the May 4, 2026 search filters
+  `semanticTypes` and `semanticGroups`.
+- Typed sync and async clients built on `httpx`.
+- Backward-compatible legacy client with the original camelCase namespaces.
+- Structured exceptions for modern clients and legacy error payloads for older
+  code.
+- JSON, JSONL, CSV, and RDF/Turtle exports.
+- Practical helpers for bulk search, bulk crosswalk, concept profiles, source
+  lookup, UMLS URL following, API-key validation, and release downloads.
+- CI across Python 3.9 through 3.14.
 
 ## Installation
 
@@ -11,15 +28,15 @@ typed sync and async clients for new applications.
 pip install umls-python-client
 ```
 
-Development install:
+For local development:
 
 ```bash
-pip install ".[dev]"
+pip install ".[dev,docs]"
 ```
 
 ## Authentication
 
-UMLS requests require an API key from NLM:
+Most UMLS requests require an API key from your UTS profile:
 https://documentation.uts.nlm.nih.gov/rest/authentication.html
 
 ```python
@@ -28,92 +45,249 @@ import os
 api_key = os.environ["UMLS_API_KEY"]
 ```
 
-## Legacy Compatible Usage
+The metadata sources endpoint is public and does not require authentication,
+but the client still uses one consistent client configuration.
 
-`UMLSClient` preserves the existing JSON formatting defaults and camelCase
-namespaces.
-
-```python
-from umls_python_client import UMLSClient
-
-client = UMLSClient(api_key="YOUR_API_KEY")
-
-results = client.searchAPI.search(
-    search_string="diabetes",
-    semantic_types="T047",
-    semantic_groups="Disorders",
-)
-print(results)
-
-raw_results = client.search_api.search(
-    search_string="diabetes",
-    return_indented=False,
-)
-```
-
-## Typed Sync Usage
+## Typed Sync Quickstart
 
 ```python
 from umls_python_client import TypedUMLSClient
 
-with TypedUMLSClient(api_key="YOUR_API_KEY") as client:
-    response = client.cui_api.get_cui_info("C0011849")
-    concept = response.result
-    print(concept.name)
+with TypedUMLSClient(api_key="YOUR_UMLS_API_KEY") as client:
+    response = client.search_api.search(
+        "diabetes",
+        semantic_groups="Disorders",
+        page_size=25,
+    )
+
+    for result in response.result:
+        print(result.ui, result.name)
 ```
 
-Typed responses return `UMLSResponse[T]`. The original UMLS JSON is available
-through `response.raw` or `response.to_dict()`, and RDF/Turtle is available with
-`response.to_rdf()`.
+Typed methods return `UMLSResponse[T]`. Use `response.result` for parsed
+models, `response.raw` or `response.to_dict()` for the original UMLS envelope,
+and `response.to_rdf()` for Turtle RDF.
 
-## Async Usage
+## Async Quickstart
 
 ```python
 from umls_python_client import AsyncUMLSClient
 
 
 async def main() -> None:
-    async with AsyncUMLSClient(api_key="YOUR_API_KEY") as client:
-        response = await client.search_api.search("diabetes", page_size=5)
+    async with AsyncUMLSClient(api_key="YOUR_UMLS_API_KEY") as client:
+        response = await client.crosswalk_api.get_crosswalk(
+            source="HPO",
+            id="HP:0001947",
+            target_source="SNOMEDCT_US",
+        )
         print(response.result)
 ```
 
-## API Namespaces
+## Legacy Compatible Usage
 
-| Namespace | Legacy alias | Coverage |
+`UMLSClient` keeps existing imports, JSON string defaults, and camelCase
+namespaces:
+
+```python
+from umls_python_client import UMLSClient
+
+client = UMLSClient(api_key="YOUR_UMLS_API_KEY")
+
+pretty_json = client.searchAPI.search("diabetes")
+raw_dict = client.search_api.search("diabetes", return_indented=False)
+rdf = client.cui_api.get_cui_info("C0011849", format="rdf")
+```
+
+Existing namespaces are preserved:
+
+- `client.searchAPI`
+- `client.sourceAPI`
+- `client.cuiAPI`
+- `client.semanticNetworkAPI`
+- `client.crosswalkAPI`
+- `client.metadataAPI`
+- `client.atomAPI`
+- `client.authAPI`
+- `client.releaseAPI`
+
+Modern namespaces are also available:
+
+- `search_api`
+- `source_api`
+- `cui_api`
+- `semantic_network_api`
+- `crosswalk_api`
+- `metadata_api`
+- `atom_api`
+- `auth_api`
+- `release_api`
+
+## Common Recipes
+
+### Semantic Search
+
+```python
+response = client.search_api.search(
+    "depression",
+    semantic_types="T047|T046",
+    semantic_groups="Disorders",
+)
+```
+
+`semantic_types` supports semantic type TUIs, semantic type names, and semantic
+tree number prefixes. Use pipes for multiple values, matching NLM's search
+documentation.
+
+### Source Code To CUI
+
+```python
+response = client.search_api.search(
+    "9468002",
+    input_type="sourceUi",
+    search_type="exact",
+    sabs="SNOMEDCT_US",
+)
+```
+
+### HPO To SNOMED CT Crosswalk
+
+```python
+response = client.crosswalk_api.get_crosswalk(
+    source="HPO",
+    id="HP:0001947",
+    target_source="SNOMEDCT_US",
+)
+```
+
+UMLS CUI crosswalks are useful starting points for mapping work. Review results
+before using them in clinical or research pipelines.
+
+### Concept Profile
+
+```python
+profile = client.cui_api.get_concept_profile(
+    "C0011849",
+    include_atoms=False,
+).result
+
+print(profile.concept.name)
+print([definition.value for definition in profile.definitions])
+```
+
+### Metadata Lookup
+
+```python
+sources = client.metadata_api.find_source(abbreviation="SNOMEDCT_US").result
+```
+
+### Bulk Workflows
+
+```python
+searches = client.search_api.bulk_search(["diabetes", "asthma"])
+crosswalks = client.crosswalk_api.bulk_crosswalk(
+    ["HP:0001947", "HP:0001250"],
+    source="HPO",
+    target_source="SNOMEDCT_US",
+)
+```
+
+### Follow UMLS URLs
+
+Many UMLS payload fields contain URLs to related resources. Follow those URLs
+with the same authenticated client:
+
+```python
+concept = client.cui_api.get_cui_info("C0011849").result
+atoms = client.follow_url(concept.raw["atoms"])
+```
+
+### Release Downloads
+
+```python
+releases = client.release_api.list_releases(
+    release_type="umls-full-release",
+    current=True,
+)
+
+client.release_api.download_file(
+    url=releases.result[0].url,
+    path="downloads",
+)
+```
+
+Call `list_releases()` without a `release_type` to inspect NLM's release
+catalog, or pass a release type such as `umls-full-release` to discover current
+download URLs.
+
+## Exports
+
+Typed responses can save themselves:
+
+```python
+response = client.search_api.search("fracture", page_size=25)
+
+response.save("exports/search", format="jsonl")
+response.save("exports/search.csv", format="csv")
+response.save("exports/search.ttl", format="rdf")
+```
+
+Clients can export any response or raw payload:
+
+```python
+client.export(response, "exports/search.json", format="json", overwrite=True)
+```
+
+Supported formats:
+
+| Format | Output |
+| --- | --- |
+| `json` | Full UMLS response envelope |
+| `jsonl` | One result record per line |
+| `csv` | Flattened scalar result fields |
+| `rdf` | Turtle RDF |
+
+If the path has a file suffix, the client writes exactly there. If the path is
+a directory or suffixless path, parent directories are created and a safe
+filename is generated.
+
+Legacy `save_to_file=True` still works and now delegates to the same export
+implementation.
+
+## Endpoint Coverage
+
+| Namespace | Coverage | Pagination behavior |
 | --- | --- | --- |
-| `search_api` | `searchAPI` | `/search/{version}`, including `semanticTypes` and `semanticGroups` |
-| `cui_api` | `cuiAPI` | CUI detail, atoms, preferred atom, definitions, relations |
-| `source_api` | `sourceAPI` | Source concepts, atoms, preferred atom, hierarchy, attributes, relations |
-| `atom_api` | none | AUI detail and hierarchy endpoints |
-| `crosswalk_api` | `crosswalkAPI` | Source identifier crosswalk |
-| `semantic_network_api` | `semanticNetworkAPI` | Semantic type lookup |
-| `metadata_api` | none | `/metadata/{version}/sources` |
+| `search_api` | `/search/{version}` with semantic filters | Sends `pageSize`; no obsolete `pageNumber` |
+| `metadata_api` | `/metadata/{version}/sources` | No auth required |
+| `cui_api` | CUI detail, atoms, preferred atom, definitions, relations | Pagination where NLM documents it |
+| `atom_api` | AUI detail, parents, children, ancestors, descendants | Sends `pageSize`; no `pageNumber` |
+| `source_api` | Source detail, atoms, preferred atom, hierarchy, attributes, relations | Pagination where NLM documents it |
+| `crosswalk_api` | Source identifier crosswalk | Supports documented pagination |
+| `semantic_network_api` | Semantic type lookup | Single resource |
+| `auth_api` | UMLS license/API-key validation | UTS validation endpoint |
+| `release_api` | Release listing and authenticated downloads | UTS release/download endpoints |
 
-## Output Behavior
+## Error Handling
 
-Legacy methods support:
-
-- `format="json"` or `format="rdf"`
-- `return_indented=True` for pretty JSON strings
-- `return_indented=False` for raw Python payloads
-- `save_to_file=True` and `file_path="output-directory"`
-
-Typed methods raise structured exceptions on failures:
+Typed clients raise structured exceptions:
 
 - `UMLSRequestError`
 - `UMLSHTTPError`
 - `UMLSDecodeError`
 
-## Current NLM API Notes
+Legacy `UMLSClient` methods keep returning error payload dictionaries instead
+of raising for UMLS request failures.
 
-The Search API changed on May 4, 2026. This client supports the current
-`semanticTypes` and `semanticGroups` filters and does not send obsolete
-`pageNumber` pagination parameters for endpoints where the current NLM docs no
-longer document pagination.
+Configure timeouts and retries at client construction:
 
-Official UMLS REST documentation:
-https://documentation.uts.nlm.nih.gov/rest/home.html
+```python
+client = TypedUMLSClient(
+    api_key="YOUR_UMLS_API_KEY",
+    timeout=20.0,
+    retries=3,
+)
+```
 
 ## Testing
 
@@ -122,38 +296,46 @@ ruff check .
 ruff format --check .
 mypy src
 pytest
+mkdocs build --strict
 python -m build
 ```
 
-Live integration tests are optional and must be explicitly enabled by setting
-`UMLS_API_KEY`; default CI uses mocked transports only.
+Live integration tests are optional and require `UMLS_API_KEY`. Tests that would
+validate user keys or download release files remain opt-in and do not run in
+default CI.
+
+## Migration Notes
+
+From `1.0.x` and `1.1.0`:
+
+- Existing imports and `UMLSClient` behavior remain supported.
+- Prefer `TypedUMLSClient` for new sync code.
+- Prefer `AsyncUMLSClient` for async applications.
+- Prefer `response.save(...)` or `client.export(...)` over new uses of
+  `save_to_file=True`.
+- Use snake_case namespaces in new code. CamelCase namespaces remain available
+  for compatibility.
+
+## Documentation
+
+- NLM UMLS REST docs: https://documentation.uts.nlm.nih.gov/rest/home.html
+- NLM auth docs: https://documentation.uts.nlm.nih.gov/rest/authentication.html
+- Project source: https://github.com/palasht75/umls-python-client
 
 ## Releases
 
-This repository uses Release Please to automate versioning and publishing.
-Commits merged to `main` should use Conventional Commit prefixes:
+This repository uses Release Please and PyPI trusted publishing. Merged commits
+should use Conventional Commit prefixes:
 
 - `fix:` for patch releases
 - `feat:` for minor releases
 - `feat!:` or `fix!:` for major releases
 
-After releasable commits land on `main`, Release Please opens or updates a
-release PR. Merging that release PR creates the GitHub Release, builds the
-package, attaches `dist/` artifacts to the release, and publishes to PyPI.
+Release Please opens a release PR. Merging that release PR creates the GitHub
+Release, builds distributions, attaches artifacts, and publishes to PyPI.
 
-To publish the already-merged `1.1.0` modernization release, first merge the
-release workflow, configure PyPI trusted publishing, and then run the `Release`
-workflow manually with `tag_name` set to `v1.1.0`. The manual run creates the
-tag and GitHub Release if needed, verifies the package, uploads release
-artifacts, and publishes `1.1.0` to PyPI.
-
-PyPI publishing uses trusted publishing, so no PyPI API token is required in
-GitHub secrets. Configure the PyPI project with:
-
-- Owner: `palasht75`
-- Repository: `umls-python-client`
-- Workflow: `release-please.yml`
-- Environment: `pypi`
+GitHub Actions must be allowed to create release PRs, or the repository must
+provide a `RELEASE_PLEASE_TOKEN` secret with PR permissions.
 
 ## License
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,35 @@
+# API Reference
+
+::: umls_python_client.clients.UMLSClient
+
+::: umls_python_client.clients.TypedUMLSClient
+
+::: umls_python_client.clients.AsyncUMLSClient
+
+::: umls_python_client.models.UMLSResponse
+
+::: umls_python_client.models.Concept
+
+::: umls_python_client.models.Atom
+
+::: umls_python_client.models.SourceAtomCluster
+
+::: umls_python_client.models.Definition
+
+::: umls_python_client.models.Relation
+
+::: umls_python_client.models.Attribute
+
+::: umls_python_client.models.SemanticType
+
+::: umls_python_client.models.RootSource
+
+::: umls_python_client.models.LicenseValidation
+
+::: umls_python_client.models.ReleaseInfo
+
+::: umls_python_client.models.ReleaseFile
+
+::: umls_python_client.models.ConceptProfile
+
+::: umls_python_client.models.UnknownRecord

--- a/docs/endpoint-coverage.md
+++ b/docs/endpoint-coverage.md
@@ -1,0 +1,20 @@
+# Endpoint Coverage
+
+| Namespace | Endpoint family | Pagination behavior |
+| --- | --- | --- |
+| `search_api` | `/search/{version}` | Sends `pageSize`; does not send obsolete `pageNumber`. |
+| `metadata_api` | `/metadata/{version}/sources` | No authentication required. |
+| `cui_api` | `/content/{version}/CUI/{CUI}` | Single resource. |
+| `cui_api` | CUI atoms and preferred atom | Sends `pageSize`; no `pageNumber`. |
+| `cui_api` | CUI definitions and relations | Supports documented `pageNumber` and `pageSize`. |
+| `atom_api` | AUI detail, parents, children, ancestors, descendants | Sends `pageSize`; no `pageNumber`. |
+| `source_api` | Source detail, atoms, preferred atom | Source atoms send `pageSize`; no atom pagination. |
+| `source_api` | Source parents, children, ancestors, descendants | Supports documented `pageNumber` and `pageSize`. |
+| `source_api` | Source attributes and relations | Supports documented `pageNumber` and `pageSize`. |
+| `crosswalk_api` | `/crosswalk/{version}/source/{source}/{id}` | Supports documented `pageNumber` and `pageSize`. |
+| `semantic_network_api` | `/semantic-network/{version}/TUI/{id}` | Single resource. |
+| `auth_api` | `https://utslogin.nlm.nih.gov/validateUser` | Text/JSON validation response. |
+| `release_api` | `https://uts-ws.nlm.nih.gov/releases` and `/download` | Release list plus authenticated file downloads. |
+
+The client accepts `version="current"` by default and supports explicit UMLS
+release strings such as `2024AA` wherever NLM supports versioned URIs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+# UMLS Python Client
+
+`umls-python-client` is a typed Python SDK for the National Library of Medicine
+UMLS Terminology Services APIs. It keeps the original `UMLSClient` interface and
+adds modern sync, async, export, and workflow helpers for production projects.
+
+## What It Covers
+
+- UMLS search, CUI content, atoms, source identifiers, metadata, crosswalk, and
+  semantic network endpoints.
+- UTS license validation and release/download endpoints.
+- Typed response models that preserve unknown fields from NLM.
+- JSON, JSONL, CSV, and RDF/Turtle exports.
+- Practical helpers for bulk search, bulk crosswalk, concept profiles, metadata
+  lookup, URL following, and documented paginated endpoints.
+
+## Install
+
+```bash
+pip install umls-python-client
+```
+
+```python
+from umls_python_client import TypedUMLSClient
+
+with TypedUMLSClient(api_key="YOUR_UMLS_API_KEY") as client:
+    response = client.search_api.search(
+        "diabetes",
+        semantic_groups="Disorders",
+    )
+    for result in response.result:
+        print(result.ui, result.name)
+```
+
+## API Key
+
+UMLS API calls require an API key from your UTS profile. The metadata sources
+endpoint does not require authentication, but the client still accepts the same
+client configuration for a consistent API.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart
+
+## Typed Sync Client
+
+```python
+import os
+
+from umls_python_client import TypedUMLSClient
+
+with TypedUMLSClient(api_key=os.environ["UMLS_API_KEY"]) as client:
+    concept = client.cui_api.get_cui_info("C0011849").result
+    print(concept.name)
+```
+
+## Async Client
+
+```python
+import os
+
+from umls_python_client import AsyncUMLSClient
+
+
+async def main() -> None:
+    async with AsyncUMLSClient(api_key=os.environ["UMLS_API_KEY"]) as client:
+        response = await client.crosswalk_api.get_crosswalk(
+            source="HPO",
+            id="HP:0001947",
+            target_source="SNOMEDCT_US",
+        )
+        print(response.result)
+```
+
+## Legacy Compatible Client
+
+```python
+from umls_python_client import UMLSClient
+
+client = UMLSClient(api_key="YOUR_UMLS_API_KEY")
+
+payload_as_json_string = client.searchAPI.search("diabetes")
+payload_as_dict = client.search_api.search("diabetes", return_indented=False)
+```
+
+The legacy client keeps camelCase namespaces and JSON string defaults for older
+applications. New code should prefer `TypedUMLSClient` or `AsyncUMLSClient`.
+
+## Exports
+
+```python
+from umls_python_client import TypedUMLSClient
+
+with TypedUMLSClient(api_key="YOUR_UMLS_API_KEY") as client:
+    response = client.search_api.search("fracture", page_size=25)
+    response.save("exports/search-results", format="jsonl")
+    client.export(response, "exports/search-results.csv", format="csv")
+```

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,83 @@
+# Recipes
+
+## Semantic Search
+
+```python
+response = client.search_api.search(
+    "depression",
+    semantic_types="T047|T046",
+    semantic_groups="Disorders",
+)
+```
+
+`semantic_types` accepts TUIs, semantic type names, or semantic tree number
+prefixes. Use pipes when sending multiple values.
+
+## Code To CUI
+
+```python
+response = client.search_api.search(
+    "9468002",
+    input_type="sourceUi",
+    search_type="exact",
+    sabs="SNOMEDCT_US",
+)
+```
+
+## Crosswalk HPO To SNOMED CT
+
+```python
+response = client.crosswalk_api.get_crosswalk(
+    source="HPO",
+    id="HP:0001947",
+    target_source="SNOMEDCT_US",
+)
+```
+
+UMLS CUI crosswalk results are a starting point for curation. Review mappings
+for clinical or research use.
+
+## Concept Profile
+
+```python
+profile = client.cui_api.get_concept_profile(
+    "C0011849",
+    include_atoms=False,
+).result
+
+print(profile.concept.name)
+print([definition.value for definition in profile.definitions])
+```
+
+## Metadata Lookup
+
+```python
+sources = client.metadata_api.find_source(abbreviation="SNOMEDCT_US").result
+```
+
+## Follow UMLS URLs
+
+Many UMLS payload fields contain URLs to related resources. Follow them without
+manually rebuilding request parameters:
+
+```python
+concept = client.cui_api.get_cui_info("C0011849").result
+atoms = client.follow_url(concept.raw["atoms"])
+```
+
+## Release Downloads
+
+```python
+releases = client.release_api.list_releases(
+    release_type="umls-full-release",
+    current=True,
+)
+client.release_api.download_file(
+    url=releases.result[0].url,
+    path="downloads",
+)
+```
+
+Call `list_releases()` without a `release_type` to inspect NLM's release
+catalog. Pass a release type such as `umls-full-release` to discover current
+download URLs before calling `download_file`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,29 @@
+# Releasing
+
+This repository uses Release Please and PyPI trusted publishing.
+
+## Normal Release Flow
+
+1. Merge feature and fix PRs into `main` with Conventional Commit messages.
+2. Release Please opens or updates a release PR.
+3. Merge the release PR.
+4. The release workflow creates the GitHub Release, builds distributions,
+   attaches artifacts, and publishes to PyPI.
+
+## Commit Types
+
+- `fix:` creates a patch release.
+- `feat:` creates a minor release.
+- `feat!:` or `fix!:` creates a major release.
+
+## Repository Settings
+
+GitHub Actions must be allowed to create pull requests, or the repository must
+provide a `RELEASE_PLEASE_TOKEN` secret with appropriate permissions.
+
+PyPI trusted publishing must point at:
+
+- Owner: `palasht75`
+- Repository: `umls-python-client`
+- Workflow: `release-please.yml`
+- Environment: `pypi`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,35 @@
+site_name: UMLS Python Client
+site_description: Production-ready Python SDK for NLM UTS and UMLS APIs.
+site_url: https://palasht75.github.io/umls-python-client/
+repo_url: https://github.com/palasht75/umls-python-client
+repo_name: palasht75/umls-python-client
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.instant
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Recipes: recipes.md
+  - Endpoint Coverage: endpoint-coverage.md
+  - API Reference: api-reference.md
+  - Releasing: releasing.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_source: false
+            show_root_heading: true
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,15 @@ dev = [
   "pytest-asyncio>=0.23.0",
   "ruff>=0.6.0",
 ]
+docs = [
+  "mkdocs>=1.6.0,<2.0",
+  "mkdocs-material>=9.5.0,<10.0",
+  "mkdocstrings[python]>=0.25.0,<1.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/palasht75/umls-python-client"
-Documentation = "https://palasht75.github.io/umls-python-client-homepage/"
+Documentation = "https://palasht75.github.io/umls-python-client/"
 Issues = "https://github.com/palasht75/umls-python-client/issues"
 Source = "https://github.com/palasht75/umls-python-client"
 
@@ -79,3 +84,7 @@ warn_unused_configs = true
 no_implicit_optional = true
 ignore_missing_imports = true
 check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = ["click", "rdflib"]
+follow_imports = "skip"

--- a/src/umls_python_client/__init__.py
+++ b/src/umls_python_client/__init__.py
@@ -5,11 +5,17 @@ from umls_python_client.errors import (
     UMLSHTTPError,
     UMLSRequestError,
 )
+from umls_python_client.exports import save_payload
 from umls_python_client.models import (
     Atom,
+    Attribute,
     Concept,
+    ConceptProfile,
     Definition,
+    LicenseValidation,
     Relation,
+    ReleaseFile,
+    ReleaseInfo,
     RootSource,
     SearchResult,
     SemanticType,
@@ -20,10 +26,15 @@ from umls_python_client.models import (
 
 __all__ = [
     "AsyncUMLSClient",
+    "Attribute",
     "Atom",
     "Concept",
+    "ConceptProfile",
     "Definition",
+    "LicenseValidation",
     "Relation",
+    "ReleaseFile",
+    "ReleaseInfo",
     "RootSource",
     "SearchResult",
     "SemanticType",
@@ -36,4 +47,5 @@ __all__ = [
     "UMLSRequestError",
     "UMLSResponse",
     "UnknownRecord",
+    "save_payload",
 ]

--- a/src/umls_python_client/apis.py
+++ b/src/umls_python_client/apis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional
 
 import httpx
 
@@ -11,7 +11,9 @@ from umls_python_client.errors import UMLSError
 from umls_python_client.formatting import render_payload, save_output_to_file
 from umls_python_client.models import (
     Atom,
+    Attribute,
     Concept,
+    ConceptProfile,
     Definition,
     Relation,
     RootSource,
@@ -195,6 +197,37 @@ class SearchAPI(UMLSAPIBase):
             default_file_name="search_{0}.txt".format(_safe_name(search_string)),
         )
 
+    def bulk_search(
+        self,
+        search_strings: Iterable[str],
+        return_indented: bool = True,
+        format: str = "json",
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+        **search_kwargs: Any,
+    ) -> Any:
+        payload = {
+            "result": [
+                {
+                    "query": search_string,
+                    "response": _as_payload(
+                        self.search(
+                            search_string,
+                            return_indented=False,
+                            **search_kwargs,
+                        )
+                    ),
+                }
+                for search_string in search_strings
+            ]
+        }
+        if save_to_file:
+            save_output_to_file(
+                payload,
+                self._resolve_file_path("bulk_search.txt", file_path),
+            )
+        return render_payload(payload, format, return_indented)
+
 
 class TypedSearchAPI(UMLSAPIBase):
     def search(
@@ -228,6 +261,16 @@ class TypedSearchAPI(UMLSAPIBase):
             ),
             model=SearchResult.from_dict,
         )
+
+    def bulk_search(
+        self,
+        search_strings: Iterable[str],
+        **search_kwargs: Any,
+    ) -> Dict[str, UMLSResponse[SearchResult]]:
+        return {
+            search_string: self.search(search_string, **search_kwargs)
+            for search_string in search_strings
+        }
 
 
 class CUIAPI(UMLSAPIBase):
@@ -351,6 +394,50 @@ class CUIAPI(UMLSAPIBase):
             default_file_name="cui_relations_{0}.txt".format(cui),
         )
 
+    def get_concept_profile(
+        self,
+        cui: str,
+        include_atoms: bool = False,
+        include_definitions: bool = True,
+        include_relations: bool = True,
+        return_indented: bool = True,
+        format: str = "json",
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+    ) -> Any:
+        payload: Dict[str, Any] = {
+            "result": {
+                "concept": _payload_result(
+                    self.get_cui_info(cui, return_indented=False)
+                ),
+                "preferredAtom": _payload_result(
+                    self.get_preferred_atom(cui, return_indented=False)
+                ),
+                "definitions": [],
+                "relations": [],
+                "atoms": [],
+            }
+        }
+        result = payload["result"]
+        if include_definitions:
+            result["definitions"] = _result_list(
+                self.get_definitions(cui, return_indented=False)
+            )
+        if include_relations:
+            result["relations"] = _result_list(
+                self.get_relations(cui, return_indented=False)
+            )
+        if include_atoms:
+            result["atoms"] = _result_list(self.get_atoms(cui, return_indented=False))
+        if save_to_file:
+            save_output_to_file(
+                payload,
+                self._resolve_file_path(
+                    "concept_profile_{0}.txt".format(cui), file_path
+                ),
+            )
+        return render_payload(payload, format, return_indented)
+
 
 class TypedCUIAPI(UMLSAPIBase):
     def get_cui_info(self, cui: str) -> UMLSResponse[Concept]:
@@ -419,6 +506,73 @@ class TypedCUIAPI(UMLSAPIBase):
                 sabs=sabs,
             ),
             model=Relation.from_dict,
+        )
+
+    def get_concept_profile(
+        self,
+        cui: str,
+        include_atoms: bool = False,
+        include_definitions: bool = True,
+        include_relations: bool = True,
+    ) -> UMLSResponse[ConceptProfile]:
+        profile_payload: Dict[str, Any] = {
+            "concept": _response_payload_result(self.get_cui_info(cui)),
+            "preferredAtom": _response_payload_result(self.get_preferred_atom(cui)),
+            "definitions": [],
+            "relations": [],
+            "atoms": [],
+        }
+        if include_definitions:
+            profile_payload["definitions"] = _response_payload_result(
+                self.get_definitions(cui)
+            )
+        if include_relations:
+            profile_payload["relations"] = _response_payload_result(
+                self.get_relations(cui)
+            )
+        if include_atoms:
+            profile_payload["atoms"] = _response_payload_result(self.get_atoms(cui))
+        return UMLSResponse(
+            result=ConceptProfile.from_dict(profile_payload),
+            raw={"result": profile_payload},
+        )
+
+    def iter_definitions(
+        self,
+        cui: str,
+        sabs: Optional[str] = None,
+        page_size: int = 25,
+    ) -> Iterator[Definition]:
+        yield from _iter_paginated(
+            lambda page_number: self.get_definitions(
+                cui,
+                sabs=sabs,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        )
+
+    def iter_relations(
+        self,
+        cui: str,
+        sabs: Optional[str] = None,
+        include_relation_labels: Optional[str] = None,
+        include_additional_labels: Optional[str] = None,
+        include_obsolete: bool = False,
+        include_suppressible: bool = False,
+        page_size: int = 200,
+    ) -> Iterator[Relation]:
+        yield from _iter_paginated(
+            lambda page_number: self.get_relations(
+                cui,
+                sabs=sabs,
+                include_relation_labels=include_relation_labels,
+                include_additional_labels=include_additional_labels,
+                include_obsolete=include_obsolete,
+                include_suppressible=include_suppressible,
+                page_number=page_number,
+                page_size=page_size,
+            )
         )
 
 
@@ -506,7 +660,7 @@ class SourceAPI(UMLSAPIBase):
         id: str,
         include_attribute_names: Optional[str] = None,
         page_number: int = 1,
-        page_size: int = 200,
+        page_size: int = 25,
         return_indented: bool = True,
         format: str = "json",
         save_to_file: bool = False,
@@ -812,6 +966,7 @@ class SourceAPI(UMLSAPIBase):
         suffix: str,
         kwargs: Dict[str, Any],
     ) -> Any:
+        default_page_size = 200 if suffix in {"ancestors", "descendants"} else 25
         return self._source_endpoint(
             source,
             id,
@@ -820,7 +975,10 @@ class SourceAPI(UMLSAPIBase):
             kwargs.pop("format", "json"),
             kwargs.pop("save_to_file", False),
             kwargs.pop("file_path", None),
-            params={"pageSize": kwargs.pop("page_size", None)},
+            params={
+                "pageNumber": kwargs.pop("page_number", 1),
+                "pageSize": kwargs.pop("page_size", default_page_size),
+            },
         )
 
     def _source_endpoint(
@@ -888,24 +1046,26 @@ class TypedSourceAPI(UMLSAPIBase):
         )
 
     def get_source_parents(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 25
     ) -> UMLSResponse[SourceAtomCluster]:
-        return self._typed_source_list(source, id, "parents", page_size)
+        return self._typed_source_list(source, id, "parents", page_number, page_size)
 
     def get_source_children(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 25
     ) -> UMLSResponse[SourceAtomCluster]:
-        return self._typed_source_list(source, id, "children", page_size)
+        return self._typed_source_list(source, id, "children", page_number, page_size)
 
     def get_source_ancestors(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 200
     ) -> UMLSResponse[SourceAtomCluster]:
-        return self._typed_source_list(source, id, "ancestors", page_size)
+        return self._typed_source_list(source, id, "ancestors", page_number, page_size)
 
     def get_source_descendants(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 200
     ) -> UMLSResponse[SourceAtomCluster]:
-        return self._typed_source_list(source, id, "descendants", page_size)
+        return self._typed_source_list(
+            source, id, "descendants", page_number, page_size
+        )
 
     def get_source_attributes(
         self,
@@ -913,8 +1073,8 @@ class TypedSourceAPI(UMLSAPIBase):
         id: str,
         include_attribute_names: Optional[str] = None,
         page_number: int = 1,
-        page_size: int = 200,
-    ) -> UMLSResponse[Any]:
+        page_size: int = 25,
+    ) -> UMLSResponse[Attribute]:
         return self._typed(
             path="/content/{0}/source/{1}/{2}/attributes".format(
                 self.version, source, id
@@ -924,6 +1084,7 @@ class TypedSourceAPI(UMLSAPIBase):
                 "pageNumber": page_number,
                 "pageSize": page_size,
             },
+            model=Attribute.from_dict,
         )
 
     def get_source_relations(
@@ -952,18 +1113,59 @@ class TypedSourceAPI(UMLSAPIBase):
             model=Relation.from_dict,
         )
 
+    def iter_source_attributes(
+        self,
+        source: str,
+        id: str,
+        include_attribute_names: Optional[str] = None,
+        page_size: int = 25,
+    ) -> Iterator[Attribute]:
+        yield from _iter_paginated(
+            lambda page_number: self.get_source_attributes(
+                source,
+                id,
+                include_attribute_names=include_attribute_names,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        )
+
+    def iter_source_relations(
+        self,
+        source: str,
+        id: str,
+        include_relation_labels: Optional[str] = None,
+        include_additional_labels: Optional[str] = None,
+        include_obsolete: bool = False,
+        include_suppressible: bool = False,
+        page_size: int = 200,
+    ) -> Iterator[Relation]:
+        yield from _iter_paginated(
+            lambda page_number: self.get_source_relations(
+                source,
+                id,
+                include_relation_labels=include_relation_labels,
+                include_additional_labels=include_additional_labels,
+                include_obsolete=include_obsolete,
+                include_suppressible=include_suppressible,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        )
+
     def _typed_source_list(
         self,
         source: str,
         id: str,
         suffix: str,
+        page_number: int,
         page_size: int,
     ) -> UMLSResponse[SourceAtomCluster]:
         return self._typed(
             path="/content/{0}/source/{1}/{2}/{3}".format(
                 self.version, source, id, suffix
             ),
-            params={"pageSize": page_size},
+            params={"pageNumber": page_number, "pageSize": page_size},
             model=SourceAtomCluster.from_dict,
         )
 
@@ -1089,6 +1291,43 @@ class CrosswalkAPI(UMLSAPIBase):
             default_file_name="crosswalk_{0}_{1}.txt".format(source, _safe_name(id)),
         )
 
+    def bulk_crosswalk(
+        self,
+        identifiers: Iterable[str],
+        source: str,
+        target_source: Optional[str] = None,
+        include_obsolete: bool = False,
+        page_size: int = 25,
+        return_indented: bool = True,
+        format: str = "json",
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+    ) -> Any:
+        payload = {
+            "result": [
+                {
+                    "id": identifier,
+                    "response": _as_payload(
+                        self.get_crosswalk(
+                            source,
+                            identifier,
+                            target_source=target_source,
+                            include_obsolete=include_obsolete,
+                            page_size=page_size,
+                            return_indented=False,
+                        )
+                    ),
+                }
+                for identifier in identifiers
+            ]
+        }
+        if save_to_file:
+            save_output_to_file(
+                payload,
+                self._resolve_file_path("bulk_crosswalk.txt", file_path),
+            )
+        return render_payload(payload, format, return_indented)
+
 
 class TypedCrosswalkAPI(UMLSAPIBase):
     def get_crosswalk(
@@ -1109,6 +1348,44 @@ class TypedCrosswalkAPI(UMLSAPIBase):
                 "pageSize": page_size,
             },
             model=SourceAtomCluster.from_dict,
+        )
+
+    def bulk_crosswalk(
+        self,
+        identifiers: Iterable[str],
+        source: str,
+        target_source: Optional[str] = None,
+        include_obsolete: bool = False,
+        page_size: int = 25,
+    ) -> Dict[str, UMLSResponse[SourceAtomCluster]]:
+        return {
+            identifier: self.get_crosswalk(
+                source,
+                identifier,
+                target_source=target_source,
+                include_obsolete=include_obsolete,
+                page_size=page_size,
+            )
+            for identifier in identifiers
+        }
+
+    def iter_crosswalk(
+        self,
+        source: str,
+        id: str,
+        target_source: Optional[str] = None,
+        include_obsolete: bool = False,
+        page_size: int = 25,
+    ) -> Iterator[SourceAtomCluster]:
+        yield from _iter_paginated(
+            lambda page_number: self.get_crosswalk(
+                source,
+                id,
+                target_source=target_source,
+                include_obsolete=include_obsolete,
+                page_number=page_number,
+                page_size=page_size,
+            )
         )
 
 
@@ -1157,6 +1434,30 @@ class MetadataAPI(UMLSAPIBase):
             auth_required=False,
         )
 
+    def find_source(
+        self,
+        abbreviation: Optional[str] = None,
+        name: Optional[str] = None,
+        return_indented: bool = True,
+        format: str = "json",
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+    ) -> Any:
+        sources = _result_list(self.get_sources(return_indented=False))
+        matched = [
+            source
+            for source in sources
+            if isinstance(source, dict)
+            and _source_matches(source, abbreviation=abbreviation, name=name)
+        ]
+        payload = {"result": matched}
+        if save_to_file:
+            save_output_to_file(
+                payload,
+                self._resolve_file_path("metadata_find_source.txt", file_path),
+            )
+        return render_payload(payload, format, return_indented)
+
 
 class TypedMetadataAPI(UMLSAPIBase):
     def get_sources(self) -> UMLSResponse[RootSource]:
@@ -1165,6 +1466,86 @@ class TypedMetadataAPI(UMLSAPIBase):
             model=RootSource.from_dict,
             auth_required=False,
         )
+
+    def find_source(
+        self,
+        abbreviation: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> UMLSResponse[RootSource]:
+        response = self.get_sources()
+        sources = _response_result_list(response)
+        matched = [
+            source
+            for source in sources
+            if isinstance(source, RootSource)
+            and _source_matches(
+                source.to_dict(),
+                abbreviation=abbreviation,
+                name=name,
+            )
+        ]
+        return UMLSResponse(
+            result=matched,
+            raw={"result": [source.to_dict() for source in matched]},
+            page_size=len(matched),
+            page_number=1,
+            page_count=1,
+        )
+
+
+def _payload_result(value: Any) -> Any:
+    payload = _as_payload(value)
+    result = payload.get("result")
+    if isinstance(result, dict) and isinstance(result.get("results"), list):
+        return result["results"]
+    return result
+
+
+def _response_payload_result(response: UMLSResponse[Any]) -> Any:
+    return _payload_result(response.to_dict())
+
+
+def _response_result_list(response: UMLSResponse[Any]) -> list[Any]:
+    result = response.result
+    if isinstance(result, list):
+        return result
+    if result is None:
+        return []
+    return [result]
+
+
+def _iter_paginated(fetch_page: Any) -> Iterator[Any]:
+    page_number = 1
+    while True:
+        response = fetch_page(page_number)
+        yield from _response_result_list(response)
+        if not response.page_count or page_number >= response.page_count:
+            break
+        page_number += 1
+
+
+def _source_matches(
+    source: Mapping[str, Any],
+    abbreviation: Optional[str],
+    name: Optional[str],
+) -> bool:
+    if abbreviation is None and name is None:
+        return True
+    if abbreviation is not None:
+        source_abbreviation = source.get("abbreviation")
+        if (
+            isinstance(source_abbreviation, str)
+            and source_abbreviation.lower() == abbreviation.lower()
+        ):
+            return True
+    if name is None:
+        return False
+    needle = name.lower()
+    for key in ("preferredName", "expandedForm", "shortName", "family"):
+        value = source.get(key)
+        if isinstance(value, str) and needle in value.lower():
+            return True
+    return False
 
 
 def _search_params(

--- a/src/umls_python_client/async_apis.py
+++ b/src/umls_python_client/async_apis.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional
+from typing import Any, AsyncIterator, Dict, Iterable, Mapping, Optional
 
 import httpx
 
 from umls_python_client.models import (
     Atom,
+    Attribute,
     Concept,
+    ConceptProfile,
     Definition,
     Relation,
     RootSource,
@@ -100,6 +102,16 @@ class AsyncSearchAPI(AsyncAPIBase):
             model=SearchResult.from_dict,
         )
 
+    async def bulk_search(
+        self,
+        search_strings: Iterable[str],
+        **search_kwargs: Any,
+    ) -> Dict[str, UMLSResponse[SearchResult]]:
+        results: Dict[str, UMLSResponse[SearchResult]] = {}
+        for search_string in search_strings:
+            results[search_string] = await self.search(search_string, **search_kwargs)
+        return results
+
 
 class AsyncCUIAPI(AsyncAPIBase):
     async def get_cui_info(self, cui: str) -> UMLSResponse[Concept]:
@@ -170,6 +182,79 @@ class AsyncCUIAPI(AsyncAPIBase):
             model=Relation.from_dict,
         )
 
+    async def get_concept_profile(
+        self,
+        cui: str,
+        include_atoms: bool = False,
+        include_definitions: bool = True,
+        include_relations: bool = True,
+    ) -> UMLSResponse[ConceptProfile]:
+        profile_payload: Dict[str, Any] = {
+            "concept": _response_payload_result(await self.get_cui_info(cui)),
+            "preferredAtom": _response_payload_result(
+                await self.get_preferred_atom(cui)
+            ),
+            "definitions": [],
+            "relations": [],
+            "atoms": [],
+        }
+        if include_definitions:
+            profile_payload["definitions"] = _response_payload_result(
+                await self.get_definitions(cui)
+            )
+        if include_relations:
+            profile_payload["relations"] = _response_payload_result(
+                await self.get_relations(cui)
+            )
+        if include_atoms:
+            profile_payload["atoms"] = _response_payload_result(
+                await self.get_atoms(cui)
+            )
+        return UMLSResponse(
+            result=ConceptProfile.from_dict(profile_payload),
+            raw={"result": profile_payload},
+        )
+
+    async def iter_definitions(
+        self,
+        cui: str,
+        sabs: Optional[str] = None,
+        page_size: int = 25,
+    ) -> AsyncIterator[Definition]:
+        async for item in _async_iter_paginated(
+            lambda page_number: self.get_definitions(
+                cui,
+                sabs=sabs,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        ):
+            yield item
+
+    async def iter_relations(
+        self,
+        cui: str,
+        sabs: Optional[str] = None,
+        include_relation_labels: Optional[str] = None,
+        include_additional_labels: Optional[str] = None,
+        include_obsolete: bool = False,
+        include_suppressible: bool = False,
+        page_size: int = 200,
+    ) -> AsyncIterator[Relation]:
+        async for item in _async_iter_paginated(
+            lambda page_number: self.get_relations(
+                cui,
+                sabs=sabs,
+                include_relation_labels=include_relation_labels,
+                include_additional_labels=include_additional_labels,
+                include_obsolete=include_obsolete,
+                include_suppressible=include_suppressible,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        ):
+            yield item
+
 
 class AsyncSourceAPI(AsyncAPIBase):
     async def get_source_concept(
@@ -210,24 +295,26 @@ class AsyncSourceAPI(AsyncAPIBase):
         )
 
     async def get_source_parents(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 25
     ) -> UMLSResponse[SourceAtomCluster]:
-        return await self._source_list(source, id, "parents", page_size)
+        return await self._source_list(source, id, "parents", page_number, page_size)
 
     async def get_source_children(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 25
     ) -> UMLSResponse[SourceAtomCluster]:
-        return await self._source_list(source, id, "children", page_size)
+        return await self._source_list(source, id, "children", page_number, page_size)
 
     async def get_source_ancestors(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 200
     ) -> UMLSResponse[SourceAtomCluster]:
-        return await self._source_list(source, id, "ancestors", page_size)
+        return await self._source_list(source, id, "ancestors", page_number, page_size)
 
     async def get_source_descendants(
-        self, source: str, id: str, page_size: int = 200
+        self, source: str, id: str, page_number: int = 1, page_size: int = 200
     ) -> UMLSResponse[SourceAtomCluster]:
-        return await self._source_list(source, id, "descendants", page_size)
+        return await self._source_list(
+            source, id, "descendants", page_number, page_size
+        )
 
     async def get_source_attributes(
         self,
@@ -235,8 +322,8 @@ class AsyncSourceAPI(AsyncAPIBase):
         id: str,
         include_attribute_names: Optional[str] = None,
         page_number: int = 1,
-        page_size: int = 200,
-    ) -> UMLSResponse[Any]:
+        page_size: int = 25,
+    ) -> UMLSResponse[Attribute]:
         return await self._typed(
             path="/content/{0}/source/{1}/{2}/attributes".format(
                 self.version, source, id
@@ -246,6 +333,7 @@ class AsyncSourceAPI(AsyncAPIBase):
                 "pageNumber": page_number,
                 "pageSize": page_size,
             },
+            model=Attribute.from_dict,
         )
 
     async def get_source_relations(
@@ -274,14 +362,56 @@ class AsyncSourceAPI(AsyncAPIBase):
             model=Relation.from_dict,
         )
 
+    async def iter_source_attributes(
+        self,
+        source: str,
+        id: str,
+        include_attribute_names: Optional[str] = None,
+        page_size: int = 25,
+    ) -> AsyncIterator[Attribute]:
+        async for item in _async_iter_paginated(
+            lambda page_number: self.get_source_attributes(
+                source,
+                id,
+                include_attribute_names=include_attribute_names,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        ):
+            yield item
+
+    async def iter_source_relations(
+        self,
+        source: str,
+        id: str,
+        include_relation_labels: Optional[str] = None,
+        include_additional_labels: Optional[str] = None,
+        include_obsolete: bool = False,
+        include_suppressible: bool = False,
+        page_size: int = 200,
+    ) -> AsyncIterator[Relation]:
+        async for item in _async_iter_paginated(
+            lambda page_number: self.get_source_relations(
+                source,
+                id,
+                include_relation_labels=include_relation_labels,
+                include_additional_labels=include_additional_labels,
+                include_obsolete=include_obsolete,
+                include_suppressible=include_suppressible,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        ):
+            yield item
+
     async def _source_list(
-        self, source: str, id: str, suffix: str, page_size: int
+        self, source: str, id: str, suffix: str, page_number: int, page_size: int
     ) -> UMLSResponse[SourceAtomCluster]:
         return await self._typed(
             path="/content/{0}/source/{1}/{2}/{3}".format(
                 self.version, source, id, suffix
             ),
-            params={"pageSize": page_size},
+            params={"pageNumber": page_number, "pageSize": page_size},
             model=SourceAtomCluster.from_dict,
         )
 
@@ -338,6 +468,45 @@ class AsyncCrosswalkAPI(AsyncAPIBase):
             model=SourceAtomCluster.from_dict,
         )
 
+    async def bulk_crosswalk(
+        self,
+        identifiers: Iterable[str],
+        source: str,
+        target_source: Optional[str] = None,
+        include_obsolete: bool = False,
+        page_size: int = 25,
+    ) -> Dict[str, UMLSResponse[SourceAtomCluster]]:
+        results: Dict[str, UMLSResponse[SourceAtomCluster]] = {}
+        for identifier in identifiers:
+            results[identifier] = await self.get_crosswalk(
+                source,
+                identifier,
+                target_source=target_source,
+                include_obsolete=include_obsolete,
+                page_size=page_size,
+            )
+        return results
+
+    async def iter_crosswalk(
+        self,
+        source: str,
+        id: str,
+        target_source: Optional[str] = None,
+        include_obsolete: bool = False,
+        page_size: int = 25,
+    ) -> AsyncIterator[SourceAtomCluster]:
+        async for item in _async_iter_paginated(
+            lambda page_number: self.get_crosswalk(
+                source,
+                id,
+                target_source=target_source,
+                include_obsolete=include_obsolete,
+                page_number=page_number,
+                page_size=page_size,
+            )
+        ):
+            yield item
+
 
 class AsyncSemanticNetworkAPI(AsyncAPIBase):
     async def get_semantic_type(self, tui: str) -> UMLSResponse[SemanticType]:
@@ -354,6 +523,86 @@ class AsyncMetadataAPI(AsyncAPIBase):
             model=RootSource.from_dict,
             auth_required=False,
         )
+
+    async def find_source(
+        self,
+        abbreviation: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> UMLSResponse[RootSource]:
+        response = await self.get_sources()
+        sources = _response_result_list(response)
+        matched = [
+            source
+            for source in sources
+            if isinstance(source, RootSource)
+            and _source_matches(
+                source.to_dict(),
+                abbreviation=abbreviation,
+                name=name,
+            )
+        ]
+        return UMLSResponse(
+            result=matched,
+            raw={"result": [source.to_dict() for source in matched]},
+            page_size=len(matched),
+            page_number=1,
+            page_count=1,
+        )
+
+
+def _payload_result(value: Mapping[str, Any]) -> Any:
+    result = value.get("result")
+    if isinstance(result, Mapping) and isinstance(result.get("results"), list):
+        return result["results"]
+    return result
+
+
+def _response_payload_result(response: UMLSResponse[Any]) -> Any:
+    return _payload_result(response.to_dict())
+
+
+def _response_result_list(response: UMLSResponse[Any]) -> list[Any]:
+    result = response.result
+    if isinstance(result, list):
+        return result
+    if result is None:
+        return []
+    return [result]
+
+
+async def _async_iter_paginated(fetch_page: Any) -> AsyncIterator[Any]:
+    page_number = 1
+    while True:
+        response = await fetch_page(page_number)
+        for item in _response_result_list(response):
+            yield item
+        if not response.page_count or page_number >= response.page_count:
+            break
+        page_number += 1
+
+
+def _source_matches(
+    source: Mapping[str, Any],
+    abbreviation: Optional[str],
+    name: Optional[str],
+) -> bool:
+    if abbreviation is None and name is None:
+        return True
+    if abbreviation is not None:
+        source_abbreviation = source.get("abbreviation")
+        if (
+            isinstance(source_abbreviation, str)
+            and source_abbreviation.lower() == abbreviation.lower()
+        ):
+            return True
+    if name is None:
+        return False
+    needle = name.lower()
+    for key in ("preferredName", "expandedForm", "shortName", "family"):
+        value = source.get(key)
+        if isinstance(value, str) and needle in value.lower():
+            return True
+    return False
 
 
 def _atom_params(

--- a/src/umls_python_client/async_uts_apis.py
+++ b/src/umls_python_client/async_uts_apis.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from umls_python_client.async_apis import AsyncAPIBase
+from umls_python_client.models import LicenseValidation, ReleaseInfo, UMLSResponse
+from umls_python_client.uts_apis import (
+    AUTH_VALIDATE_URL,
+    DOWNLOAD_URL,
+    RELEASES_URL,
+    _download_path,
+    _normalize_release_payload,
+    _validation_payload_from_text,
+)
+
+
+class AsyncAuthAPI(AsyncAPIBase):
+    async def validate_user(
+        self,
+        user_api_key: Optional[str] = None,
+        validator_api_key: Optional[str] = None,
+    ) -> UMLSResponse[LicenseValidation]:
+        text = await self._transport.request_text(
+            absolute_url=AUTH_VALIDATE_URL,
+            params={
+                "validatorApiKey": validator_api_key or self.api_key,
+                "apiKey": user_api_key or self.api_key,
+            },
+            auth_required=False,
+        )
+        payload = _validation_payload_from_text(text)
+        return UMLSResponse.from_payload(
+            {"result": payload},
+            model=LicenseValidation.from_dict,
+        )
+
+    async def validate_api_key(
+        self,
+        api_key: Optional[str] = None,
+        validator_api_key: Optional[str] = None,
+    ) -> UMLSResponse[LicenseValidation]:
+        return await self.validate_user(
+            user_api_key=api_key,
+            validator_api_key=validator_api_key,
+        )
+
+
+class AsyncReleaseAPI(AsyncAPIBase):
+    async def list_releases(
+        self,
+        release_type: Optional[str] = None,
+        current: Optional[bool] = None,
+    ) -> UMLSResponse[ReleaseInfo]:
+        payload = await self._transport.request(
+            absolute_url=RELEASES_URL,
+            params={"releaseType": release_type, "current": current},
+            auth_required=False,
+        )
+        return UMLSResponse.from_payload(
+            _normalize_release_payload(payload),
+            model=ReleaseInfo.from_dict,
+        )
+
+    async def get_releases(self, **kwargs: Any) -> UMLSResponse[ReleaseInfo]:
+        return await self.list_releases(**kwargs)
+
+    async def download_file(
+        self,
+        url: str,
+        path: Union[str, Path],
+        overwrite: bool = False,
+    ) -> Path:
+        target = _download_path(url, Path(path))
+        if target.exists() and not overwrite:
+            raise FileExistsError("{0} already exists.".format(target))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = await self._transport.request_bytes(
+            absolute_url=DOWNLOAD_URL,
+            params={"url": url},
+            auth_required=True,
+        )
+        target.write_bytes(content)
+        return target

--- a/src/umls_python_client/clients.py
+++ b/src/umls_python_client/clients.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import httpx
 
@@ -29,7 +30,18 @@ from umls_python_client.async_apis import (
     AsyncSemanticNetworkAPI,
     AsyncSourceAPI,
 )
+from umls_python_client.async_uts_apis import AsyncAuthAPI, AsyncReleaseAPI
+from umls_python_client.errors import UMLSError
+from umls_python_client.exports import save_payload
+from umls_python_client.formatting import render_payload
+from umls_python_client.models import UMLSResponse
 from umls_python_client.transport import AsyncUMLSTransport, SyncUMLSTransport
+from umls_python_client.uts_apis import (
+    AuthAPI,
+    ReleaseAPI,
+    TypedAuthAPI,
+    TypedReleaseAPI,
+)
 
 
 class UMLSClient:
@@ -62,12 +74,53 @@ class UMLSClient:
         self.crosswalk_api = CrosswalkAPI(version=version, transport=self._transport)
         self.metadata_api = MetadataAPI(version=version, transport=self._transport)
         self.atom_api = AtomAPI(version=version, transport=self._transport)
+        self.auth_api = AuthAPI(version=version, transport=self._transport)
+        self.release_api = ReleaseAPI(version=version, transport=self._transport)
 
         self.searchAPI = self.search_api
         self.sourceAPI = self.source_api
         self.cuiAPI = self.cui_api
         self.semanticNetworkAPI = self.semantic_network_api
         self.crosswalkAPI = self.crosswalk_api
+        self.metadataAPI = self.metadata_api
+        self.atomAPI = self.atom_api
+        self.authAPI = self.auth_api
+        self.releaseAPI = self.release_api
+
+    def export(
+        self,
+        response_or_payload: Any,
+        path: Union[str, Path],
+        format: str = "json",
+        overwrite: bool = False,
+    ) -> Path:
+        return save_payload(
+            response_or_payload,
+            path,
+            format=format,
+            overwrite=overwrite,
+        )
+
+    def follow_url(
+        self,
+        url: str,
+        return_indented: bool = True,
+        format: str = "json",
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+    ) -> Any:
+        try:
+            payload = self._transport.request(absolute_url=url)
+        except UMLSError as exc:
+            payload = exc.to_dict()
+        if save_to_file:
+            save_payload(
+                payload,
+                file_path or "umls_follow_url.txt",
+                format="json",
+                overwrite=True,
+            )
+        return render_payload(payload, format, return_indented)
 
     def close(self) -> None:
         self._transport.close()
@@ -111,6 +164,26 @@ class TypedUMLSClient:
         )
         self.metadata_api = TypedMetadataAPI(version=version, transport=self._transport)
         self.atom_api = TypedAtomAPI(version=version, transport=self._transport)
+        self.auth_api = TypedAuthAPI(version=version, transport=self._transport)
+        self.release_api = TypedReleaseAPI(version=version, transport=self._transport)
+
+    def export(
+        self,
+        response_or_payload: Any,
+        path: Union[str, Path],
+        format: str = "json",
+        overwrite: bool = False,
+    ) -> Path:
+        return save_payload(
+            response_or_payload,
+            path,
+            format=format,
+            overwrite=overwrite,
+        )
+
+    def follow_url(self, url: str) -> UMLSResponse[Any]:
+        payload = self._transport.request(absolute_url=url)
+        return UMLSResponse.from_payload(payload)
 
     def close(self) -> None:
         self._transport.close()
@@ -154,6 +227,26 @@ class AsyncUMLSClient:
         )
         self.metadata_api = AsyncMetadataAPI(version=version, transport=self._transport)
         self.atom_api = AsyncAtomAPI(version=version, transport=self._transport)
+        self.auth_api = AsyncAuthAPI(version=version, transport=self._transport)
+        self.release_api = AsyncReleaseAPI(version=version, transport=self._transport)
+
+    def export(
+        self,
+        response_or_payload: Any,
+        path: Union[str, Path],
+        format: str = "json",
+        overwrite: bool = False,
+    ) -> Path:
+        return save_payload(
+            response_or_payload,
+            path,
+            format=format,
+            overwrite=overwrite,
+        )
+
+    async def follow_url(self, url: str) -> UMLSResponse[Any]:
+        payload = await self._transport.request(absolute_url=url)
+        return UMLSResponse.from_payload(payload)
 
     async def aclose(self) -> None:
         await self._transport.aclose()

--- a/src/umls_python_client/exports.py
+++ b/src/umls_python_client/exports.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence, Union
+
+VALID_EXPORT_FORMATS = {"json", "jsonl", "csv", "rdf"}
+_EXTENSIONS = {
+    "json": ".json",
+    "jsonl": ".jsonl",
+    "csv": ".csv",
+    "rdf": ".ttl",
+}
+
+
+def save_payload(
+    payload: Any,
+    path: Union[str, Path],
+    *,
+    format: str = "json",
+    overwrite: bool = False,
+    default_stem: str = "umls_response",
+) -> Path:
+    """Save a UMLS payload or response object to disk."""
+    output_format = _normalize_format(format)
+    target = _resolve_output_path(Path(path), output_format, default_stem)
+    if target.exists() and not overwrite:
+        raise FileExistsError("{0} already exists.".format(target))
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    if output_format == "json":
+        target.write_text(
+            json.dumps(_to_payload(payload), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    elif output_format == "jsonl":
+        lines = [
+            json.dumps(item, ensure_ascii=False, default=str)
+            for item in records_from_payload(payload)
+        ]
+        target.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    elif output_format == "csv":
+        _write_csv(target, records_from_payload(payload))
+    else:
+        from umls_python_client.formatting import to_rdf
+
+        target.write_text(to_rdf(_to_payload(payload)), encoding="utf-8")
+
+    return target
+
+
+def records_from_payload(payload: Any) -> list[Any]:
+    """Return the record list represented by a UMLS payload."""
+    value = _to_payload(payload)
+    if isinstance(value, Mapping):
+        if isinstance(value.get("releaseTypes"), list):
+            return list(value["releaseTypes"])
+        result = value.get("result", value)
+        if isinstance(result, Mapping) and isinstance(result.get("results"), list):
+            return list(result["results"])
+        if isinstance(result, list):
+            return list(result)
+        return [result]
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _write_csv(path: Path, records: Sequence[Any]) -> None:
+    rows = [_flatten_record(record) for record in records]
+    fieldnames = _fieldnames(rows)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        if not fieldnames:
+            handle.write("")
+            return
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _flatten_record(record: Any) -> dict[str, Any]:
+    if not isinstance(record, Mapping):
+        return {"value": record}
+    flattened: dict[str, Any] = {}
+    _flatten_mapping(record, flattened)
+    return flattened
+
+
+def _flatten_mapping(
+    record: Mapping[str, Any],
+    flattened: dict[str, Any],
+    prefix: str = "",
+) -> None:
+    for key, value in record.items():
+        name = "{0}.{1}".format(prefix, key) if prefix else str(key)
+        if isinstance(value, Mapping):
+            _flatten_mapping(value, flattened, name)
+        elif isinstance(value, list):
+            flattened[name] = _flatten_list(value)
+        else:
+            flattened[name] = value
+
+
+def _flatten_list(value: list[Any]) -> str:
+    if all(not isinstance(item, (Mapping, list)) for item in value):
+        return "|".join("" if item is None else str(item) for item in value)
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _fieldnames(rows: Iterable[Mapping[str, Any]]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for name in row:
+            if name not in seen:
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def _to_payload(payload: Any) -> Any:
+    if hasattr(payload, "to_dict"):
+        return payload.to_dict()
+    return payload
+
+
+def _resolve_output_path(path: Path, output_format: str, default_stem: str) -> Path:
+    if path.exists() and path.is_dir():
+        return path / "{0}{1}".format(
+            _safe_stem(default_stem), _EXTENSIONS[output_format]
+        )
+    if path.suffix:
+        return path
+    return path / "{0}{1}".format(_safe_stem(default_stem), _EXTENSIONS[output_format])
+
+
+def _normalize_format(output_format: str) -> str:
+    normalized = output_format.lower()
+    if normalized not in VALID_EXPORT_FORMATS:
+        allowed = ", ".join(sorted(VALID_EXPORT_FORMATS))
+        raise ValueError(
+            "Invalid export format '{0}'. Allowed formats: {1}.".format(
+                output_format,
+                allowed,
+            )
+        )
+    return normalized
+
+
+def _safe_stem(value: str) -> str:
+    stem = "".join(
+        char if char.isalnum() or char in {"-", "_"} else "_" for char in value
+    ).strip("_")
+    return stem or "umls_response"

--- a/src/umls_python_client/formatting.py
+++ b/src/umls_python_client/formatting.py
@@ -33,10 +33,14 @@ def render_payload(
 
 def save_output_to_file(response: Any, file_path: str) -> None:
     """Save response data to a file, creating parent directories as needed."""
-    path = Path(file_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    content = response if isinstance(response, str) else json.dumps(response, indent=4)
-    path.write_text(content, encoding="utf-8")
+    from umls_python_client.exports import save_payload
+
+    if isinstance(response, str):
+        path = Path(file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(response, encoding="utf-8")
+        return
+    save_payload(response, file_path, format="json", overwrite=True)
 
 
 def to_rdf(

--- a/src/umls_python_client/models.py
+++ b/src/umls_python_client/models.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, TypeVar
+from pathlib import Path
+from typing import Any, Callable, Dict, Generic, List, Mapping, Optional, TypeVar, Union
 
 T = TypeVar("T")
 
@@ -15,6 +16,14 @@ def _get(data: Mapping[str, Any], *names: str) -> Any:
         if name in data:
             return data[name]
     return None
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "valid", "1", "yes"}
+    return bool(value)
 
 
 @dataclass
@@ -165,6 +174,26 @@ class Relation(Record):
 
 
 @dataclass
+class Attribute(Record):
+    ui: Optional[str] = None
+    source_ui: Optional[str] = None
+    root_source: Optional[str] = None
+    name: Optional[str] = None
+    value: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Attribute":
+        return cls(
+            raw=_as_dict(data),
+            ui=_get(data, "ui"),
+            source_ui=_get(data, "sourceUi"),
+            root_source=_get(data, "rootSource"),
+            name=_get(data, "name"),
+            value=_get(data, "value"),
+        )
+
+
+@dataclass
 class SemanticType(Record):
     ui: Optional[str] = None
     name: Optional[str] = None
@@ -204,6 +233,110 @@ class RootSource(Record):
         )
 
 
+@dataclass
+class LicenseValidation(Record):
+    valid: bool = False
+    status_code: Optional[int] = None
+    message: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LicenseValidation":
+        valid = _get(data, "valid", "isValid")
+        return cls(
+            raw=_as_dict(data),
+            valid=_to_bool(valid),
+            status_code=_get(data, "statusCode", "status_code"),
+            message=_get(data, "message", "detail"),
+        )
+
+
+@dataclass
+class ReleaseFile(Record):
+    name: Optional[str] = None
+    release_type: Optional[str] = None
+    url: Optional[str] = None
+    published_date: Optional[str] = None
+    product: Optional[str] = None
+    release_version: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReleaseFile":
+        return cls(
+            raw=_as_dict(data),
+            name=_get(data, "name", "fileName", "filename"),
+            release_type=_get(data, "releaseType", "type"),
+            url=_get(data, "url", "downloadUrl", "downloadURL"),
+            published_date=_get(data, "publishedDate", "releaseDate", "date"),
+            product=_get(data, "product"),
+            release_version=_get(data, "releaseVersion", "version"),
+        )
+
+
+@dataclass
+class ReleaseInfo(Record):
+    name: Optional[str] = None
+    release_type: Optional[str] = None
+    current: Optional[bool] = None
+    url: Optional[str] = None
+    product: Optional[str] = None
+    endpoint: Optional[str] = None
+    file_name: Optional[str] = None
+    release_version: Optional[str] = None
+    release_date: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ReleaseInfo":
+        return cls(
+            raw=_as_dict(data),
+            name=_get(data, "name", "releaseName", "fileName", "releaseType"),
+            release_type=_get(data, "releaseType", "type"),
+            current=_to_bool(_get(data, "current", "isCurrent")),
+            url=_get(data, "url", "downloadUrl", "downloadURL", "endpoint"),
+            product=_get(data, "product"),
+            endpoint=_get(data, "endpoint"),
+            file_name=_get(data, "fileName", "filename"),
+            release_version=_get(data, "releaseVersion", "version"),
+            release_date=_get(data, "releaseDate", "publishedDate", "date"),
+        )
+
+
+@dataclass
+class ConceptProfile(Record):
+    concept: Optional[Concept] = None
+    preferred_atom: Optional[Atom] = None
+    definitions: List[Definition] = field(default_factory=list)
+    relations: List[Relation] = field(default_factory=list)
+    atoms: List[Atom] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ConceptProfile":
+        concept = data.get("concept")
+        preferred_atom = data.get("preferredAtom") or data.get("preferred_atom")
+        definitions = data.get("definitions") or []
+        relations = data.get("relations") or []
+        atoms = data.get("atoms") or []
+        return cls(
+            raw=_as_dict(data),
+            concept=Concept.from_dict(concept)
+            if isinstance(concept, Mapping)
+            else None,
+            preferred_atom=Atom.from_dict(preferred_atom)
+            if isinstance(preferred_atom, Mapping)
+            else None,
+            definitions=[
+                Definition.from_dict(item)
+                for item in definitions
+                if isinstance(item, Mapping)
+            ],
+            relations=[
+                Relation.from_dict(item)
+                for item in relations
+                if isinstance(item, Mapping)
+            ],
+            atoms=[Atom.from_dict(item) for item in atoms if isinstance(item, Mapping)],
+        )
+
+
 RecordFactory = Callable[[Mapping[str, Any]], T]
 
 
@@ -225,6 +358,8 @@ class UMLSResponse(Generic[T]):
     ) -> "UMLSResponse[T]":
         raw = _as_dict(payload)
         result = raw.get("result")
+        if result is None and isinstance(raw.get("releaseTypes"), list):
+            result = raw["releaseTypes"]
         parsed: Any
 
         if isinstance(result, list):
@@ -252,6 +387,16 @@ class UMLSResponse(Generic[T]):
 
         return to_rdf(self.raw)
 
+    def save(
+        self,
+        path: Union[str, Path],
+        format: str = "json",
+        overwrite: bool = False,
+    ) -> Path:
+        from umls_python_client.exports import save_payload
+
+        return save_payload(self, path, format=format, overwrite=overwrite)
+
 
 def _parse_item(
     item: Any,
@@ -276,6 +421,8 @@ def model_for_class_type(data: Mapping[str, Any]) -> type[Record]:
         return Definition
     if class_type in {"ConceptRelation", "AtomClusterRelation", "AtomRelation"}:
         return Relation
+    if class_type == "Attribute":
+        return Attribute
     if class_type in {"SemanticType", "SemanticNetworkRelation"}:
         return SemanticType
     if class_type == "RootSource":

--- a/src/umls_python_client/transport.py
+++ b/src/umls_python_client/transport.py
@@ -70,6 +70,49 @@ class SyncUMLSTransport:
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
     ) -> Dict[str, Any]:
+        return _decode_response(
+            self._request_response(path, params, absolute_url, auth_required)
+        )
+
+    def request_text(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        absolute_url: Optional[str] = None,
+        auth_required: bool = True,
+    ) -> str:
+        response = self._request_response(path, params, absolute_url, auth_required)
+        if response.status_code >= 400:
+            raise UMLSHTTPError(
+                status_code=response.status_code,
+                message=response.text,
+                url=str(response.url),
+            )
+        return response.text
+
+    def request_bytes(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        absolute_url: Optional[str] = None,
+        auth_required: bool = True,
+    ) -> bytes:
+        response = self._request_response(path, params, absolute_url, auth_required)
+        if response.status_code >= 400:
+            raise UMLSHTTPError(
+                status_code=response.status_code,
+                message=response.text,
+                url=str(response.url),
+            )
+        return response.content
+
+    def _request_response(
+        self,
+        path: Optional[str],
+        params: Optional[Mapping[str, Any]],
+        absolute_url: Optional[str],
+        auth_required: bool,
+    ) -> httpx.Response:
         if bool(path) == bool(absolute_url):
             raise ValueError("Provide exactly one of path or absolute_url.")
         request_params = clean_params(params)
@@ -91,7 +134,7 @@ class SyncUMLSTransport:
             if response.status_code in RETRY_STATUSES and attempt < self.retries:
                 _sleep(attempt, self.backoff_factor)
                 continue
-            return _decode_response(response)
+            return response
 
         raise UMLSRequestError(str(last_exc) if last_exc else "Request failed.")
 
@@ -139,6 +182,53 @@ class AsyncUMLSTransport:
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
     ) -> Dict[str, Any]:
+        return _decode_response(
+            await self._request_response(path, params, absolute_url, auth_required)
+        )
+
+    async def request_text(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        absolute_url: Optional[str] = None,
+        auth_required: bool = True,
+    ) -> str:
+        response = await self._request_response(
+            path, params, absolute_url, auth_required
+        )
+        if response.status_code >= 400:
+            raise UMLSHTTPError(
+                status_code=response.status_code,
+                message=response.text,
+                url=str(response.url),
+            )
+        return response.text
+
+    async def request_bytes(
+        self,
+        path: Optional[str] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        absolute_url: Optional[str] = None,
+        auth_required: bool = True,
+    ) -> bytes:
+        response = await self._request_response(
+            path, params, absolute_url, auth_required
+        )
+        if response.status_code >= 400:
+            raise UMLSHTTPError(
+                status_code=response.status_code,
+                message=response.text,
+                url=str(response.url),
+            )
+        return response.content
+
+    async def _request_response(
+        self,
+        path: Optional[str],
+        params: Optional[Mapping[str, Any]],
+        absolute_url: Optional[str],
+        auth_required: bool,
+    ) -> httpx.Response:
         if bool(path) == bool(absolute_url):
             raise ValueError("Provide exactly one of path or absolute_url.")
         request_params = clean_params(params)
@@ -160,7 +250,7 @@ class AsyncUMLSTransport:
             if response.status_code in RETRY_STATUSES and attempt < self.retries:
                 await _async_sleep(attempt, self.backoff_factor)
                 continue
-            return _decode_response(response)
+            return response
 
         raise UMLSRequestError(str(last_exc) if last_exc else "Request failed.")
 

--- a/src/umls_python_client/uts_apis.py
+++ b/src/umls_python_client/uts_apis.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+from urllib.parse import urlparse
+
+from umls_python_client.apis import UMLSAPIBase
+from umls_python_client.errors import UMLSError
+from umls_python_client.exports import save_payload
+from umls_python_client.formatting import render_payload
+from umls_python_client.models import LicenseValidation, ReleaseInfo, UMLSResponse
+
+AUTH_VALIDATE_URL = "https://utslogin.nlm.nih.gov/validateUser"
+DOWNLOAD_URL = "https://uts-ws.nlm.nih.gov/download"
+RELEASES_URL = "https://uts-ws.nlm.nih.gov/releases"
+
+
+class AuthAPI(UMLSAPIBase):
+    """Backward-compatible UMLS license validation helper."""
+
+    def validate_user(
+        self,
+        user_api_key: Optional[str] = None,
+        validator_api_key: Optional[str] = None,
+        return_indented: bool = True,
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+        format: str = "json",
+    ) -> Any:
+        payload = self._validation_payload(user_api_key, validator_api_key)
+        if save_to_file:
+            save_payload(
+                payload,
+                self._resolve_file_path("license_validation.txt", file_path),
+                format="json",
+                overwrite=True,
+            )
+        return render_payload(payload, format, return_indented)
+
+    def validate_api_key(self, api_key: Optional[str] = None, **kwargs: Any) -> Any:
+        return self.validate_user(user_api_key=api_key, **kwargs)
+
+    def _validation_payload(
+        self,
+        user_api_key: Optional[str],
+        validator_api_key: Optional[str],
+    ) -> dict[str, Any]:
+        try:
+            text = self._transport.request_text(
+                absolute_url=AUTH_VALIDATE_URL,
+                params={
+                    "validatorApiKey": validator_api_key or self.api_key,
+                    "apiKey": user_api_key or self.api_key,
+                },
+                auth_required=False,
+            )
+        except UMLSError as exc:
+            payload = exc.to_dict()
+            payload["valid"] = False
+            return payload
+        return _validation_payload_from_text(text)
+
+
+class TypedAuthAPI(UMLSAPIBase):
+    def validate_user(
+        self,
+        user_api_key: Optional[str] = None,
+        validator_api_key: Optional[str] = None,
+    ) -> UMLSResponse[LicenseValidation]:
+        text = self._transport.request_text(
+            absolute_url=AUTH_VALIDATE_URL,
+            params={
+                "validatorApiKey": validator_api_key or self.api_key,
+                "apiKey": user_api_key or self.api_key,
+            },
+            auth_required=False,
+        )
+        payload = _validation_payload_from_text(text)
+        return UMLSResponse.from_payload(
+            {"result": payload},
+            model=LicenseValidation.from_dict,
+        )
+
+    def validate_api_key(
+        self,
+        api_key: Optional[str] = None,
+        validator_api_key: Optional[str] = None,
+    ) -> UMLSResponse[LicenseValidation]:
+        return self.validate_user(
+            user_api_key=api_key,
+            validator_api_key=validator_api_key,
+        )
+
+
+class ReleaseAPI(UMLSAPIBase):
+    """Backward-compatible release listing and download helper."""
+
+    def list_releases(
+        self,
+        release_type: Optional[str] = None,
+        current: Optional[bool] = None,
+        return_indented: bool = True,
+        save_to_file: bool = False,
+        file_path: Optional[str] = None,
+        format: str = "json",
+    ) -> Any:
+        return self._request_formatted(
+            absolute_url=RELEASES_URL,
+            params={"releaseType": release_type, "current": current},
+            output_format=format,
+            return_indented=return_indented,
+            save_to_file=save_to_file,
+            file_path=file_path,
+            default_file_name="umls_releases.txt",
+            auth_required=False,
+        )
+
+    def get_releases(self, **kwargs: Any) -> Any:
+        return self.list_releases(**kwargs)
+
+    def download_file(
+        self,
+        url: str,
+        path: Union[str, Path],
+        overwrite: bool = False,
+    ) -> Path:
+        target = _download_path(url, Path(path))
+        if target.exists() and not overwrite:
+            raise FileExistsError("{0} already exists.".format(target))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = self._transport.request_bytes(
+            absolute_url=DOWNLOAD_URL,
+            params={"url": url},
+            auth_required=True,
+        )
+        target.write_bytes(content)
+        return target
+
+
+class TypedReleaseAPI(UMLSAPIBase):
+    def list_releases(
+        self,
+        release_type: Optional[str] = None,
+        current: Optional[bool] = None,
+    ) -> UMLSResponse[ReleaseInfo]:
+        payload = self._transport.request(
+            absolute_url=RELEASES_URL,
+            params={"releaseType": release_type, "current": current},
+            auth_required=False,
+        )
+        return UMLSResponse.from_payload(
+            _normalize_release_payload(payload),
+            model=ReleaseInfo.from_dict,
+        )
+
+    def get_releases(self, **kwargs: Any) -> UMLSResponse[ReleaseInfo]:
+        return self.list_releases(**kwargs)
+
+    def download_file(
+        self,
+        url: str,
+        path: Union[str, Path],
+        overwrite: bool = False,
+    ) -> Path:
+        target = _download_path(url, Path(path))
+        if target.exists() and not overwrite:
+            raise FileExistsError("{0} already exists.".format(target))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = self._transport.request_bytes(
+            absolute_url=DOWNLOAD_URL,
+            params={"url": url},
+            auth_required=True,
+        )
+        target.write_bytes(content)
+        return target
+
+
+def _validation_payload_from_text(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    try:
+        parsed = json.loads(stripped)
+    except ValueError:
+        valid = stripped.lower() in {"true", "valid", "1", "yes"}
+        return {"valid": valid, "message": stripped}
+    if isinstance(parsed, Mapping):
+        payload = dict(parsed)
+        payload.setdefault(
+            "valid", _truthy(payload.get("valid", payload.get("result")))
+        )
+        return payload
+    return {"valid": _truthy(parsed), "message": stripped}
+
+
+def _normalize_release_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if isinstance(payload.get("releaseTypes"), list):
+        normalized = dict(payload)
+        normalized["result"] = payload["releaseTypes"]
+        return normalized
+    return dict(payload)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "valid", "1", "yes"}
+    return bool(value)
+
+
+def _download_path(url: str, path: Path) -> Path:
+    if path.exists() and path.is_dir():
+        parsed = urlparse(url)
+        name = Path(parsed.path).name or "umls_download"
+        return path / name
+    if path.suffix:
+        return path
+    parsed = urlparse(url)
+    name = Path(parsed.path).name or "umls_download"
+    return path / name

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -34,3 +34,50 @@ async def test_async_client_returns_typed_response() -> None:
     assert isinstance(response.result, list)
     assert isinstance(response.result[0], SearchResult)
     assert response.result[0].name == "Diabetes Mellitus"
+
+
+@pytest.mark.asyncio
+async def test_async_helpers_auth_release_and_bulk_search(tmp_path) -> None:
+    seen: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.host == "utslogin.nlm.nih.gov":
+            return httpx.Response(200, text="true")
+        if request.url.path == "/releases":
+            return httpx.Response(
+                200,
+                json={
+                    "releaseTypes": [
+                        {
+                            "product": "UMLS",
+                            "releaseType": "UMLS Full Release",
+                            "endpoint": "https://uts-ws.nlm.nih.gov/releases?releaseType=umls-full-release",
+                        }
+                    ]
+                },
+            )
+        if request.url.path == "/download":
+            return httpx.Response(200, content=b"archive")
+        return httpx.Response(
+            200,
+            json={"result": {"results": [{"ui": "C1", "name": "Diabetes"}]}},
+        )
+
+    async with AsyncUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    ) as client:
+        validation = await client.auth_api.validate_user("user-key")
+        releases = await client.release_api.list_releases(current=True)
+        searches = await client.search_api.bulk_search(["diabetes", "asthma"])
+        output = await client.release_api.download_file(
+            "https://download.nlm.nih.gov/umls/kss/example.zip",
+            tmp_path,
+        )
+
+    assert validation.result.valid is True
+    assert releases.result[0].product == "UMLS"
+    assert set(searches) == {"diabetes", "asthma"}
+    assert output.read_bytes() == b"archive"
+    assert seen[0].url.params["validatorApiKey"] == "secret"

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -20,6 +20,10 @@ def test_existing_import_paths_and_aliases_work(mock_transport) -> None:
     assert client.cui_api is client.cuiAPI
     assert client.semantic_network_api is client.semanticNetworkAPI
     assert client.crosswalk_api is client.crosswalkAPI
+    assert client.metadata_api is client.metadataAPI
+    assert client.atom_api is client.atomAPI
+    assert client.auth_api is client.authAPI
+    assert client.release_api is client.releaseAPI
 
 
 def test_legacy_json_string_default_and_raw_mode(mock_transport) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import csv
+import json
+
+import httpx
+import pytest
+
+from umls_python_client import UMLSClient, UMLSResponse
+
+
+def test_response_save_jsonl_csv_and_rdf(tmp_path) -> None:
+    response = UMLSResponse.from_payload(
+        {
+            "result": [
+                {"classType": "Concept", "ui": "C1", "name": "First"},
+                {"classType": "Concept", "ui": "C2", "name": "Second"},
+            ]
+        }
+    )
+
+    jsonl_path = response.save(tmp_path / "records", format="jsonl")
+    csv_path = response.save(tmp_path / "records.csv", format="csv")
+    rdf_path = response.save(tmp_path / "records.ttl", format="rdf")
+
+    assert jsonl_path == tmp_path / "records" / "umls_response.jsonl"
+    assert json.loads(jsonl_path.read_text().splitlines()[0])["ui"] == "C1"
+
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert rows[1]["name"] == "Second"
+    assert "First" in rdf_path.read_text()
+
+
+def test_export_overwrite_is_explicit(tmp_path) -> None:
+    response = UMLSResponse.from_payload({"result": {"ui": "C1"}})
+    target = response.save(tmp_path / "payload.json", format="json")
+
+    with pytest.raises(FileExistsError):
+        response.save(target, format="json")
+
+    response.save(target, format="json", overwrite=True)
+    assert json.loads(target.read_text())["result"]["ui"] == "C1"
+
+
+def test_client_export_handles_existing_directory_with_suffix(tmp_path) -> None:
+    response = UMLSResponse.from_payload(
+        {"releaseTypes": [{"product": "UMLS", "releaseType": "UMLS Full Release"}]}
+    )
+    directory = tmp_path / "exports.v1"
+    directory.mkdir()
+
+    with UMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(lambda _request: httpx.Response(200)),
+    ) as client:
+        output = client.export(response, directory, format="jsonl")
+
+    assert output == directory / "umls_response.jsonl"
+    assert json.loads(output.read_text())["product"] == "UMLS"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+
+import httpx
+
+from umls_python_client import ConceptProfile, TypedUMLSClient, UMLSClient
+
+
+def test_auth_validation_constructs_uts_login_request(
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, text="true")
+
+    client = UMLSClient(
+        api_key="validator",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    payload = client.auth_api.validate_user("user-key", return_indented=False)
+
+    assert payload["valid"] is True
+    assert captured_requests[0].url.host == "utslogin.nlm.nih.gov"
+    assert captured_requests[0].url.params["validatorApiKey"] == "validator"
+    assert captured_requests[0].url.params["apiKey"] == "user-key"
+
+
+def test_release_list_and_download_requests(
+    tmp_path,
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        if request.url.path == "/download":
+            return httpx.Response(200, content=b"archive")
+        return httpx.Response(
+            200,
+            json={
+                "releaseTypes": [
+                    {
+                        "product": "UMLS",
+                        "releaseType": "UMLS Full Release",
+                        "endpoint": "https://uts-ws.nlm.nih.gov/releases?releaseType=umls-full-release",
+                    }
+                ]
+            },
+        )
+
+    with ExitStack() as stack:
+        client = stack.enter_context(
+            UMLSClient(
+                api_key="secret",
+                http_transport=httpx.MockTransport(handler),
+            )
+        )
+        typed_client = stack.enter_context(
+            TypedUMLSClient(
+                api_key="secret",
+                http_transport=httpx.MockTransport(handler),
+            )
+        )
+        releases = client.release_api.list_releases(current=True, return_indented=False)
+        typed_releases = typed_client.release_api.list_releases(current=True)
+        output = client.release_api.download_file(
+            "https://download.nlm.nih.gov/umls/kss/example.zip",
+            tmp_path,
+        )
+
+    assert releases["releaseTypes"][0]["product"] == "UMLS"
+    assert typed_releases.result[0].product == "UMLS"
+    assert typed_releases.result[0].url.endswith("umls-full-release")
+    assert "apiKey" not in captured_requests[0].url.params
+    assert "apiKey" not in captured_requests[1].url.params
+    assert captured_requests[2].url.params["apiKey"] == "secret"
+    assert captured_requests[2].url.params["url"].endswith("example.zip")
+    assert output.read_bytes() == b"archive"
+
+
+def test_typed_concept_profile_and_follow_url(
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        path = request.url.path
+        if path.endswith("/atoms/preferred"):
+            return httpx.Response(
+                200,
+                json={"result": {"classType": "Atom", "ui": "A1", "name": "Diabetes"}},
+            )
+        if path.endswith("/definitions"):
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": 1,
+                    "pageCount": 1,
+                    "result": [{"classType": "Definition", "value": "Definition"}],
+                },
+            )
+        if path.endswith("/relations"):
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": 1,
+                    "pageCount": 1,
+                    "result": [{"classType": "ConceptRelation", "ui": "R1"}],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "classType": "Concept",
+                    "ui": "C0011849",
+                    "name": "Diabetes",
+                    "atoms": "https://uts-ws.nlm.nih.gov/rest/content/current/CUI/C0011849/atoms",
+                }
+            },
+        )
+
+    client = TypedUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    profile = client.cui_api.get_concept_profile("C0011849").result
+    followed = client.follow_url(profile.concept.raw["atoms"])
+
+    assert isinstance(profile, ConceptProfile)
+    assert profile.concept.name == "Diabetes"
+    assert profile.definitions[0].value == "Definition"
+    assert followed.raw["result"]["ui"] == "C0011849"
+    assert captured_requests[-1].url.params["apiKey"] == "secret"
+
+
+def test_bulk_helpers_metadata_lookup_and_paginated_iterator(
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        path = request.url.path
+        if path.endswith("/sources"):
+            return httpx.Response(
+                200,
+                json={
+                    "result": [
+                        {
+                            "classType": "RootSource",
+                            "abbreviation": "SNOMEDCT_US",
+                            "preferredName": "SNOMED CT US Edition",
+                        }
+                    ]
+                },
+            )
+        if path.endswith("/relations"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [{"classType": "ConceptRelation", "ui": f"R{page}"}],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"result": {"results": [{"ui": "C1", "name": "Diabetes"}]}},
+        )
+
+    client = TypedUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    searches = client.search_api.bulk_search(["diabetes", "asthma"])
+    sources = client.metadata_api.find_source(abbreviation="SNOMEDCT_US")
+    relations = list(client.cui_api.iter_relations("C0011849"))
+
+    assert set(searches) == {"diabetes", "asthma"}
+    assert sources.result[0].abbreviation == "SNOMEDCT_US"
+    assert [relation.ui for relation in relations] == ["R1", "R2"]
+
+
+def test_source_hierarchy_keeps_documented_pagination(
+    captured_requests: list[httpx.Request],
+    mock_transport,
+) -> None:
+    client = UMLSClient(
+        api_key="secret",
+        http_transport=mock_transport({"result": []}),
+    )
+
+    client.source_api.get_source_parents(
+        "SNOMEDCT_US",
+        "9468002",
+        page_number=3,
+        page_size=10,
+        return_indented=False,
+    )
+    client.atom_api.get_parents("A123", page_size=10, return_indented=False)
+
+    assert captured_requests[0].url.params["pageNumber"] == "3"
+    assert "pageNumber" not in captured_requests[1].url.params


### PR DESCRIPTION
## Summary
- Adds UTS auth and release/download APIs, typed sync/async helpers, URL following, bulk workflows, concept profiles, and documented paginated iterators.
- Reworks exports around `UMLSResponse.save(...)` and `client.export(...)` with JSON, JSONL, CSV, and RDF output while preserving legacy `save_to_file` behavior.
- Expands public models and rewrites README plus MkDocs Material documentation.
- Adds docs validation to CI and release publishing workflows.

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy src`
- `pytest` (`26 passed, 1 skipped`)
- `mkdocs build --strict`
- `python -m build`

## Risk
- Backward compatibility is preserved for `UMLSClient`, existing camelCase namespaces, JSON string defaults, RDF mode, and legacy file output.
- `pyproject.toml` remains at `1.1.0`; Release Please should create the `1.2.0` version/changelog PR after this `feat:` change is merged.