### PR TITLE
fix: harden SDK URL and export behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ print(profile.concept.name)
 print([definition.value for definition in profile.definitions])
 ```
 
+Concept profiles fetch all documented definition and relation pages by default.
+Pass `all_pages=False` to keep the older first-page-only behavior.
+
 ### Metadata Lookup
 
 ```python
@@ -201,6 +204,9 @@ with the same authenticated client:
 concept = client.cui_api.get_cui_info("C0011849").result
 atoms = client.follow_url(concept.raw["atoms"])
 ```
+
+Authenticated URL following is restricted to trusted UMLS/UTS hosts so an API
+key is never attached to arbitrary third-party URLs.
 
 ### Release Downloads
 

--- a/docs/endpoint-coverage.md
+++ b/docs/endpoint-coverage.md
@@ -6,7 +6,7 @@
 | `metadata_api` | `/metadata/{version}/sources` | No authentication required. |
 | `cui_api` | `/content/{version}/CUI/{CUI}` | Single resource. |
 | `cui_api` | CUI atoms and preferred atom | Sends `pageSize`; no `pageNumber`. |
-| `cui_api` | CUI definitions and relations | Supports documented `pageNumber` and `pageSize`. |
+| `cui_api` | CUI definitions and relations | Supports documented `pageNumber` and `pageSize`; concept profiles fetch all pages by default. |
 | `atom_api` | AUI detail, parents, children, ancestors, descendants | Sends `pageSize`; no `pageNumber`. |
 | `source_api` | Source detail, atoms, preferred atom | Source atoms send `pageSize`; no atom pagination. |
 | `source_api` | Source parents, children, ancestors, descendants | Supports documented `pageNumber` and `pageSize`. |
@@ -14,7 +14,7 @@
 | `crosswalk_api` | `/crosswalk/{version}/source/{source}/{id}` | Supports documented `pageNumber` and `pageSize`. |
 | `semantic_network_api` | `/semantic-network/{version}/TUI/{id}` | Single resource. |
 | `auth_api` | `https://utslogin.nlm.nih.gov/validateUser` | Text/JSON validation response. |
-| `release_api` | `https://uts-ws.nlm.nih.gov/releases` and `/download` | Release list plus authenticated file downloads. |
+| `release_api` | `https://uts-ws.nlm.nih.gov/releases` and `/download` | Release list plus authenticated file downloads with redirect handling. |
 
 The client accepts `version="current"` by default and supports explicit UMLS
 release strings such as `2024AA` wherever NLM supports versioned URIs.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -49,6 +49,9 @@ print(profile.concept.name)
 print([definition.value for definition in profile.definitions])
 ```
 
+Profiles fetch all documented definition and relation pages by default. Use
+`all_pages=False` when you only want the first page.
+
 ## Metadata Lookup
 
 ```python
@@ -64,6 +67,9 @@ manually rebuilding request parameters:
 concept = client.cui_api.get_cui_info("C0011849").result
 atoms = client.follow_url(concept.raw["atoms"])
 ```
+
+The client only attaches your API key to trusted UMLS/UTS hosts when following
+absolute URLs.
 
 ## Release Downloads
 

--- a/src/umls_python_client/apis.py
+++ b/src/umls_python_client/apis.py
@@ -22,7 +22,7 @@ from umls_python_client.models import (
     SourceAtomCluster,
     UMLSResponse,
 )
-from umls_python_client.transport import SyncUMLSTransport
+from umls_python_client.transport import SyncUMLSTransport, request_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +144,15 @@ class UMLSAPIBase:
             absolute_url=absolute_url,
             auth_required=auth_required,
         )
-        return UMLSResponse.from_payload(payload, model=model)
+        return UMLSResponse.from_payload(
+            payload,
+            model=model,
+            request_metadata=request_metadata(
+                path=path,
+                absolute_url=absolute_url,
+                params=params,
+            ),
+        )
 
     def close(self) -> None:
         if self._owns_transport:
@@ -404,6 +412,10 @@ class CUIAPI(UMLSAPIBase):
         format: str = "json",
         save_to_file: bool = False,
         file_path: Optional[str] = None,
+        *,
+        all_pages: bool = True,
+        definitions_page_size: int = 25,
+        relations_page_size: int = 25,
     ) -> Any:
         payload: Dict[str, Any] = {
             "result": {
@@ -420,13 +432,41 @@ class CUIAPI(UMLSAPIBase):
         }
         result = payload["result"]
         if include_definitions:
-            result["definitions"] = _result_list(
-                self.get_definitions(cui, return_indented=False)
-            )
+            if all_pages:
+                result["definitions"] = _legacy_paginated_result_list(
+                    lambda page_number: self.get_definitions(
+                        cui,
+                        page_number=page_number,
+                        page_size=definitions_page_size,
+                        return_indented=False,
+                    )
+                )
+            else:
+                result["definitions"] = _result_list(
+                    self.get_definitions(
+                        cui,
+                        page_size=definitions_page_size,
+                        return_indented=False,
+                    )
+                )
         if include_relations:
-            result["relations"] = _result_list(
-                self.get_relations(cui, return_indented=False)
-            )
+            if all_pages:
+                result["relations"] = _legacy_paginated_result_list(
+                    lambda page_number: self.get_relations(
+                        cui,
+                        page_number=page_number,
+                        page_size=relations_page_size,
+                        return_indented=False,
+                    )
+                )
+            else:
+                result["relations"] = _result_list(
+                    self.get_relations(
+                        cui,
+                        page_size=relations_page_size,
+                        return_indented=False,
+                    )
+                )
         if include_atoms:
             result["atoms"] = _result_list(self.get_atoms(cui, return_indented=False))
         if save_to_file:
@@ -514,6 +554,10 @@ class TypedCUIAPI(UMLSAPIBase):
         include_atoms: bool = False,
         include_definitions: bool = True,
         include_relations: bool = True,
+        *,
+        all_pages: bool = True,
+        definitions_page_size: int = 25,
+        relations_page_size: int = 25,
     ) -> UMLSResponse[ConceptProfile]:
         profile_payload: Dict[str, Any] = {
             "concept": _response_payload_result(self.get_cui_info(cui)),
@@ -523,18 +567,46 @@ class TypedCUIAPI(UMLSAPIBase):
             "atoms": [],
         }
         if include_definitions:
-            profile_payload["definitions"] = _response_payload_result(
-                self.get_definitions(cui)
-            )
+            if all_pages:
+                profile_payload["definitions"] = [
+                    item.to_dict()
+                    for item in self.iter_definitions(
+                        cui,
+                        page_size=definitions_page_size,
+                    )
+                ]
+            else:
+                profile_payload["definitions"] = _response_payload_result(
+                    self.get_definitions(cui, page_size=definitions_page_size)
+                )
         if include_relations:
-            profile_payload["relations"] = _response_payload_result(
-                self.get_relations(cui)
-            )
+            if all_pages:
+                profile_payload["relations"] = [
+                    item.to_dict()
+                    for item in self.iter_relations(
+                        cui,
+                        page_size=relations_page_size,
+                    )
+                ]
+            else:
+                profile_payload["relations"] = _response_payload_result(
+                    self.get_relations(cui, page_size=relations_page_size)
+                )
         if include_atoms:
             profile_payload["atoms"] = _response_payload_result(self.get_atoms(cui))
         return UMLSResponse(
             result=ConceptProfile.from_dict(profile_payload),
             raw={"result": profile_payload},
+            request_metadata=request_metadata(
+                path="/content/{0}/CUI/{1}".format(self.version, cui),
+                params={
+                    "profile": True,
+                    "allPages": all_pages,
+                    "includeAtoms": include_atoms,
+                    "includeDefinitions": include_definitions,
+                    "includeRelations": include_relations,
+                },
+            ),
         )
 
     def iter_definitions(
@@ -1522,6 +1594,31 @@ def _iter_paginated(fetch_page: Any) -> Iterator[Any]:
         if not response.page_count or page_number >= response.page_count:
             break
         page_number += 1
+
+
+def _legacy_paginated_result_list(fetch_page: Any) -> list[Any]:
+    results: list[Any] = []
+    page_number = 1
+    while True:
+        payload = _as_payload(fetch_page(page_number))
+        result = payload.get("result", [])
+        if isinstance(result, list):
+            results.extend(result)
+        page_count = _page_count(payload)
+        if not page_count or page_number >= page_count:
+            break
+        page_number += 1
+    return results
+
+
+def _page_count(payload: Mapping[str, Any]) -> Optional[int]:
+    value = payload.get("pageCount")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _source_matches(

--- a/src/umls_python_client/async_apis.py
+++ b/src/umls_python_client/async_apis.py
@@ -17,7 +17,7 @@ from umls_python_client.models import (
     SourceAtomCluster,
     UMLSResponse,
 )
-from umls_python_client.transport import AsyncUMLSTransport
+from umls_python_client.transport import AsyncUMLSTransport, request_metadata
 
 
 class AsyncAPIBase:
@@ -62,7 +62,15 @@ class AsyncAPIBase:
             absolute_url=absolute_url,
             auth_required=auth_required,
         )
-        return UMLSResponse.from_payload(payload, model=model)
+        return UMLSResponse.from_payload(
+            payload,
+            model=model,
+            request_metadata=request_metadata(
+                path=path,
+                absolute_url=absolute_url,
+                params=params,
+            ),
+        )
 
     async def aclose(self) -> None:
         if self._owns_transport:
@@ -188,6 +196,10 @@ class AsyncCUIAPI(AsyncAPIBase):
         include_atoms: bool = False,
         include_definitions: bool = True,
         include_relations: bool = True,
+        *,
+        all_pages: bool = True,
+        definitions_page_size: int = 25,
+        relations_page_size: int = 25,
     ) -> UMLSResponse[ConceptProfile]:
         profile_payload: Dict[str, Any] = {
             "concept": _response_payload_result(await self.get_cui_info(cui)),
@@ -199,13 +211,37 @@ class AsyncCUIAPI(AsyncAPIBase):
             "atoms": [],
         }
         if include_definitions:
-            profile_payload["definitions"] = _response_payload_result(
-                await self.get_definitions(cui)
-            )
+            if all_pages:
+                profile_payload["definitions"] = [
+                    item.to_dict()
+                    async for item in self.iter_definitions(
+                        cui,
+                        page_size=definitions_page_size,
+                    )
+                ]
+            else:
+                profile_payload["definitions"] = _response_payload_result(
+                    await self.get_definitions(
+                        cui,
+                        page_size=definitions_page_size,
+                    )
+                )
         if include_relations:
-            profile_payload["relations"] = _response_payload_result(
-                await self.get_relations(cui)
-            )
+            if all_pages:
+                profile_payload["relations"] = [
+                    item.to_dict()
+                    async for item in self.iter_relations(
+                        cui,
+                        page_size=relations_page_size,
+                    )
+                ]
+            else:
+                profile_payload["relations"] = _response_payload_result(
+                    await self.get_relations(
+                        cui,
+                        page_size=relations_page_size,
+                    )
+                )
         if include_atoms:
             profile_payload["atoms"] = _response_payload_result(
                 await self.get_atoms(cui)
@@ -213,6 +249,16 @@ class AsyncCUIAPI(AsyncAPIBase):
         return UMLSResponse(
             result=ConceptProfile.from_dict(profile_payload),
             raw={"result": profile_payload},
+            request_metadata=request_metadata(
+                path="/content/{0}/CUI/{1}".format(self.version, cui),
+                params={
+                    "profile": True,
+                    "allPages": all_pages,
+                    "includeAtoms": include_atoms,
+                    "includeDefinitions": include_definitions,
+                    "includeRelations": include_relations,
+                },
+            ),
         )
 
     async def iter_definitions(

--- a/src/umls_python_client/async_uts_apis.py
+++ b/src/umls_python_client/async_uts_apis.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Union
 
 from umls_python_client.async_apis import AsyncAPIBase
 from umls_python_client.models import LicenseValidation, ReleaseInfo, UMLSResponse
+from umls_python_client.transport import request_metadata
 from umls_python_client.uts_apis import (
     AUTH_VALIDATE_URL,
     DOWNLOAD_URL,
@@ -21,18 +22,23 @@ class AsyncAuthAPI(AsyncAPIBase):
         user_api_key: Optional[str] = None,
         validator_api_key: Optional[str] = None,
     ) -> UMLSResponse[LicenseValidation]:
+        params = {
+            "validatorApiKey": validator_api_key or self.api_key,
+            "apiKey": user_api_key or self.api_key,
+        }
         text = await self._transport.request_text(
             absolute_url=AUTH_VALIDATE_URL,
-            params={
-                "validatorApiKey": validator_api_key or self.api_key,
-                "apiKey": user_api_key or self.api_key,
-            },
+            params=params,
             auth_required=False,
         )
         payload = _validation_payload_from_text(text)
         return UMLSResponse.from_payload(
             {"result": payload},
             model=LicenseValidation.from_dict,
+            request_metadata=request_metadata(
+                absolute_url=AUTH_VALIDATE_URL,
+                params=params,
+            ),
         )
 
     async def validate_api_key(
@@ -52,14 +58,19 @@ class AsyncReleaseAPI(AsyncAPIBase):
         release_type: Optional[str] = None,
         current: Optional[bool] = None,
     ) -> UMLSResponse[ReleaseInfo]:
+        params = {"releaseType": release_type, "current": current}
         payload = await self._transport.request(
             absolute_url=RELEASES_URL,
-            params={"releaseType": release_type, "current": current},
+            params=params,
             auth_required=False,
         )
         return UMLSResponse.from_payload(
             _normalize_release_payload(payload),
             model=ReleaseInfo.from_dict,
+            request_metadata=request_metadata(
+                absolute_url=RELEASES_URL,
+                params=params,
+            ),
         )
 
     async def get_releases(self, **kwargs: Any) -> UMLSResponse[ReleaseInfo]:
@@ -79,6 +90,7 @@ class AsyncReleaseAPI(AsyncAPIBase):
             absolute_url=DOWNLOAD_URL,
             params={"url": url},
             auth_required=True,
+            follow_redirects=True,
         )
         target.write_bytes(content)
         return target

--- a/src/umls_python_client/clients.py
+++ b/src/umls_python_client/clients.py
@@ -35,7 +35,11 @@ from umls_python_client.errors import UMLSError
 from umls_python_client.exports import save_payload
 from umls_python_client.formatting import render_payload
 from umls_python_client.models import UMLSResponse
-from umls_python_client.transport import AsyncUMLSTransport, SyncUMLSTransport
+from umls_python_client.transport import (
+    AsyncUMLSTransport,
+    SyncUMLSTransport,
+    request_metadata,
+)
 from umls_python_client.uts_apis import (
     AuthAPI,
     ReleaseAPI,
@@ -183,7 +187,10 @@ class TypedUMLSClient:
 
     def follow_url(self, url: str) -> UMLSResponse[Any]:
         payload = self._transport.request(absolute_url=url)
-        return UMLSResponse.from_payload(payload)
+        return UMLSResponse.from_payload(
+            payload,
+            request_metadata=request_metadata(absolute_url=url),
+        )
 
     def close(self) -> None:
         self._transport.close()
@@ -246,7 +253,10 @@ class AsyncUMLSClient:
 
     async def follow_url(self, url: str) -> UMLSResponse[Any]:
         payload = await self._transport.request(absolute_url=url)
-        return UMLSResponse.from_payload(payload)
+        return UMLSResponse.from_payload(
+            payload,
+            request_metadata=request_metadata(absolute_url=url),
+        )
 
     async def aclose(self) -> None:
         await self._transport.aclose()

--- a/src/umls_python_client/exports.py
+++ b/src/umls_python_client/exports.py
@@ -4,6 +4,7 @@ import csv
 import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence, Union
+from urllib.parse import urlparse
 
 VALID_EXPORT_FORMATS = {"json", "jsonl", "csv", "rdf"}
 _EXTENSIONS = {
@@ -24,6 +25,7 @@ def save_payload(
 ) -> Path:
     """Save a UMLS payload or response object to disk."""
     output_format = _normalize_format(format)
+    default_stem = _default_stem(payload, default_stem)
     target = _resolve_output_path(Path(path), output_format, default_stem)
     if target.exists() and not overwrite:
         raise FileExistsError("{0} already exists.".format(target))
@@ -152,4 +154,51 @@ def _safe_stem(value: str) -> str:
     stem = "".join(
         char if char.isalnum() or char in {"-", "_"} else "_" for char in value
     ).strip("_")
+    if len(stem) > 160:
+        stem = stem[:160].rstrip("_")
     return stem or "umls_response"
+
+
+def _default_stem(payload: Any, fallback: str) -> str:
+    metadata = getattr(payload, "request_metadata", None)
+    if isinstance(metadata, Mapping):
+        stem = _stem_from_metadata(metadata)
+        if stem:
+            return stem
+    return fallback
+
+
+def _stem_from_metadata(metadata: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    source = metadata.get("path") or metadata.get("absolute_url")
+    if isinstance(source, str):
+        parsed = urlparse(source)
+        source_path = parsed.path if parsed.scheme or parsed.netloc else source
+        parts.extend(
+            segment
+            for segment in source_path.split("/")
+            if segment and segment != "rest"
+        )
+
+    params = metadata.get("params")
+    if isinstance(params, Mapping):
+        preferred_keys = (
+            "string",
+            "ui",
+            "id",
+            "source",
+            "targetSource",
+            "releaseType",
+        )
+        keys = [key for key in preferred_keys if key in params] + [
+            key for key in sorted(params) if key not in preferred_keys
+        ]
+        for key in keys:
+            if key.lower() in {"apikey", "validatorapikey"}:
+                continue
+            value = params[key]
+            if value is None or value == "":
+                continue
+            parts.append("{0}_{1}".format(key, value))
+
+    return "_".join(str(part) for part in parts)

--- a/src/umls_python_client/models.py
+++ b/src/umls_python_client/models.py
@@ -26,6 +26,12 @@ def _to_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _to_optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    return _to_bool(value)
+
+
 @dataclass
 class Record:
     """Base record with unknown-field preservation."""
@@ -290,7 +296,7 @@ class ReleaseInfo(Record):
             raw=_as_dict(data),
             name=_get(data, "name", "releaseName", "fileName", "releaseType"),
             release_type=_get(data, "releaseType", "type"),
-            current=_to_bool(_get(data, "current", "isCurrent")),
+            current=_to_optional_bool(_get(data, "current", "isCurrent")),
             url=_get(data, "url", "downloadUrl", "downloadURL", "endpoint"),
             product=_get(data, "product"),
             endpoint=_get(data, "endpoint"),
@@ -349,12 +355,14 @@ class UMLSResponse(Generic[T]):
     page_size: Optional[int] = None
     page_number: Optional[int] = None
     page_count: Optional[int] = None
+    request_metadata: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_payload(
         cls,
         payload: Mapping[str, Any],
         model: Optional[RecordFactory[T]] = None,
+        request_metadata: Optional[Mapping[str, Any]] = None,
     ) -> "UMLSResponse[T]":
         raw = _as_dict(payload)
         result = raw.get("result")
@@ -377,6 +385,9 @@ class UMLSResponse(Generic[T]):
             page_size=_get(raw, "pageSize"),
             page_number=_get(raw, "pageNumber"),
             page_count=_get(raw, "pageCount"),
+            request_metadata=_as_dict(request_metadata)
+            if request_metadata is not None
+            else None,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/umls_python_client/transport.py
+++ b/src/umls_python_client/transport.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from typing import Any, Dict, Mapping, Optional
+from urllib.parse import urlparse
 
 import httpx
 
@@ -13,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "https://uts-ws.nlm.nih.gov/rest"
 RETRY_STATUSES = {429, 500, 502, 503, 504}
+TRUSTED_AUTH_HOSTS = {"uts-ws.nlm.nih.gov"}
+SENSITIVE_METADATA_PARAMS = {"apikey", "validatorapikey"}
 
 
 def clean_params(params: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
@@ -29,6 +32,27 @@ def clean_params(params: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
         else:
             cleaned[key] = value
     return cleaned
+
+
+def request_metadata(
+    *,
+    path: Optional[str] = None,
+    absolute_url: Optional[str] = None,
+    params: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    if path is not None:
+        metadata["path"] = path
+    if absolute_url is not None:
+        metadata["absolute_url"] = absolute_url
+    cleaned_params = {
+        key: value
+        for key, value in clean_params(params).items()
+        if key.lower() not in SENSITIVE_METADATA_PARAMS
+    }
+    if cleaned_params:
+        metadata["params"] = cleaned_params
+    return metadata
 
 
 class SyncUMLSTransport:
@@ -69,9 +93,12 @@ class SyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> Dict[str, Any]:
         return _decode_response(
-            self._request_response(path, params, absolute_url, auth_required)
+            self._request_response(
+                path, params, absolute_url, auth_required, follow_redirects
+            )
         )
 
     def request_text(
@@ -80,8 +107,11 @@ class SyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> str:
-        response = self._request_response(path, params, absolute_url, auth_required)
+        response = self._request_response(
+            path, params, absolute_url, auth_required, follow_redirects
+        )
         if response.status_code >= 400:
             raise UMLSHTTPError(
                 status_code=response.status_code,
@@ -96,8 +126,11 @@ class SyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> bytes:
-        response = self._request_response(path, params, absolute_url, auth_required)
+        response = self._request_response(
+            path, params, absolute_url, auth_required, follow_redirects
+        )
         if response.status_code >= 400:
             raise UMLSHTTPError(
                 status_code=response.status_code,
@@ -112,18 +145,24 @@ class SyncUMLSTransport:
         params: Optional[Mapping[str, Any]],
         absolute_url: Optional[str],
         auth_required: bool,
+        follow_redirects: bool,
     ) -> httpx.Response:
         if bool(path) == bool(absolute_url):
             raise ValueError("Provide exactly one of path or absolute_url.")
         request_params = clean_params(params)
-        if auth_required:
-            request_params["apiKey"] = self.api_key
         url = absolute_url or _normalize_path(path)
+        if auth_required:
+            _validate_authenticated_absolute_url(absolute_url, self.base_url)
+            request_params["apiKey"] = self.api_key
 
         last_exc: Optional[httpx.RequestError] = None
         for attempt in range(self.retries + 1):
             try:
-                response = self.client.get(url, params=request_params)
+                response = self.client.get(
+                    url,
+                    params=request_params,
+                    follow_redirects=follow_redirects,
+                )
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt == self.retries:
@@ -181,9 +220,12 @@ class AsyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> Dict[str, Any]:
         return _decode_response(
-            await self._request_response(path, params, absolute_url, auth_required)
+            await self._request_response(
+                path, params, absolute_url, auth_required, follow_redirects
+            )
         )
 
     async def request_text(
@@ -192,9 +234,10 @@ class AsyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> str:
         response = await self._request_response(
-            path, params, absolute_url, auth_required
+            path, params, absolute_url, auth_required, follow_redirects
         )
         if response.status_code >= 400:
             raise UMLSHTTPError(
@@ -210,9 +253,10 @@ class AsyncUMLSTransport:
         params: Optional[Mapping[str, Any]] = None,
         absolute_url: Optional[str] = None,
         auth_required: bool = True,
+        follow_redirects: bool = False,
     ) -> bytes:
         response = await self._request_response(
-            path, params, absolute_url, auth_required
+            path, params, absolute_url, auth_required, follow_redirects
         )
         if response.status_code >= 400:
             raise UMLSHTTPError(
@@ -228,18 +272,24 @@ class AsyncUMLSTransport:
         params: Optional[Mapping[str, Any]],
         absolute_url: Optional[str],
         auth_required: bool,
+        follow_redirects: bool,
     ) -> httpx.Response:
         if bool(path) == bool(absolute_url):
             raise ValueError("Provide exactly one of path or absolute_url.")
         request_params = clean_params(params)
-        if auth_required:
-            request_params["apiKey"] = self.api_key
         url = absolute_url or _normalize_path(path)
+        if auth_required:
+            _validate_authenticated_absolute_url(absolute_url, self.base_url)
+            request_params["apiKey"] = self.api_key
 
         last_exc: Optional[httpx.RequestError] = None
         for attempt in range(self.retries + 1):
             try:
-                response = await self.client.get(url, params=request_params)
+                response = await self.client.get(
+                    url,
+                    params=request_params,
+                    follow_redirects=follow_redirects,
+                )
             except httpx.RequestError as exc:
                 last_exc = exc
                 if attempt == self.retries:
@@ -263,6 +313,27 @@ def _normalize_path(path: Optional[str]) -> str:
     if path is None:
         raise ValueError("path is required.")
     return "/" + path.lstrip("/")
+
+
+def _validate_authenticated_absolute_url(
+    absolute_url: Optional[str],
+    base_url: str,
+) -> None:
+    if absolute_url is None:
+        return
+
+    host = urlparse(absolute_url).hostname
+    base_host = urlparse(base_url).hostname
+    allowed_hosts = {
+        allowed_host.lower()
+        for allowed_host in (base_host, *TRUSTED_AUTH_HOSTS)
+        if allowed_host
+    }
+    if not host or host.lower() not in allowed_hosts:
+        display_host = host or "unknown host"
+        raise UMLSRequestError(
+            "Refusing to send UMLS API key to untrusted host: {0}.".format(display_host)
+        )
 
 
 def _decode_response(response: httpx.Response) -> Dict[str, Any]:

--- a/src/umls_python_client/uts_apis.py
+++ b/src/umls_python_client/uts_apis.py
@@ -10,6 +10,7 @@ from umls_python_client.errors import UMLSError
 from umls_python_client.exports import save_payload
 from umls_python_client.formatting import render_payload
 from umls_python_client.models import LicenseValidation, ReleaseInfo, UMLSResponse
+from umls_python_client.transport import request_metadata
 
 AUTH_VALIDATE_URL = "https://utslogin.nlm.nih.gov/validateUser"
 DOWNLOAD_URL = "https://uts-ws.nlm.nih.gov/download"
@@ -68,18 +69,23 @@ class TypedAuthAPI(UMLSAPIBase):
         user_api_key: Optional[str] = None,
         validator_api_key: Optional[str] = None,
     ) -> UMLSResponse[LicenseValidation]:
+        params = {
+            "validatorApiKey": validator_api_key or self.api_key,
+            "apiKey": user_api_key or self.api_key,
+        }
         text = self._transport.request_text(
             absolute_url=AUTH_VALIDATE_URL,
-            params={
-                "validatorApiKey": validator_api_key or self.api_key,
-                "apiKey": user_api_key or self.api_key,
-            },
+            params=params,
             auth_required=False,
         )
         payload = _validation_payload_from_text(text)
         return UMLSResponse.from_payload(
             {"result": payload},
             model=LicenseValidation.from_dict,
+            request_metadata=request_metadata(
+                absolute_url=AUTH_VALIDATE_URL,
+                params=params,
+            ),
         )
 
     def validate_api_key(
@@ -133,6 +139,7 @@ class ReleaseAPI(UMLSAPIBase):
             absolute_url=DOWNLOAD_URL,
             params={"url": url},
             auth_required=True,
+            follow_redirects=True,
         )
         target.write_bytes(content)
         return target
@@ -144,14 +151,19 @@ class TypedReleaseAPI(UMLSAPIBase):
         release_type: Optional[str] = None,
         current: Optional[bool] = None,
     ) -> UMLSResponse[ReleaseInfo]:
+        params = {"releaseType": release_type, "current": current}
         payload = self._transport.request(
             absolute_url=RELEASES_URL,
-            params={"releaseType": release_type, "current": current},
+            params=params,
             auth_required=False,
         )
         return UMLSResponse.from_payload(
             _normalize_release_payload(payload),
             model=ReleaseInfo.from_dict,
+            request_metadata=request_metadata(
+                absolute_url=RELEASES_URL,
+                params=params,
+            ),
         )
 
     def get_releases(self, **kwargs: Any) -> UMLSResponse[ReleaseInfo]:
@@ -171,6 +183,7 @@ class TypedReleaseAPI(UMLSAPIBase):
             absolute_url=DOWNLOAD_URL,
             params={"url": url},
             auth_required=True,
+            follow_redirects=True,
         )
         target.write_bytes(content)
         return target

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from umls_python_client import AsyncUMLSClient, SearchResult
+from umls_python_client.errors import UMLSRequestError
 
 
 @pytest.mark.asyncio
@@ -58,6 +59,11 @@ async def test_async_helpers_auth_release_and_bulk_search(tmp_path) -> None:
                 },
             )
         if request.url.path == "/download":
+            return httpx.Response(
+                302,
+                headers={"location": "https://uts-ws.nlm.nih.gov/final.zip"},
+            )
+        if request.url.path == "/final.zip":
             return httpx.Response(200, content=b"archive")
         return httpx.Response(
             200,
@@ -78,6 +84,83 @@ async def test_async_helpers_auth_release_and_bulk_search(tmp_path) -> None:
 
     assert validation.result.valid is True
     assert releases.result[0].product == "UMLS"
+    assert releases.result[0].current is None
     assert set(searches) == {"diabetes", "asthma"}
     assert output.read_bytes() == b"archive"
     assert seen[0].url.params["validatorApiKey"] == "secret"
+    zip_paths = [
+        request.url.path for request in seen if request.url.path.endswith(".zip")
+    ]
+    assert zip_paths == ["/final.zip"]
+
+
+@pytest.mark.asyncio
+async def test_async_follow_url_rejects_untrusted_hosts_before_request() -> None:
+    seen: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"result": []})
+
+    async with AsyncUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(UMLSRequestError):
+            await client.follow_url("https://example.com/not-umls")
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_async_concept_profile_collects_all_documented_pages() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/atoms/preferred"):
+            return httpx.Response(
+                200,
+                json={"result": {"classType": "Atom", "ui": "A1", "name": "Diabetes"}},
+            )
+        if path.endswith("/definitions"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [
+                        {
+                            "classType": "Definition",
+                            "value": "Definition {0}".format(page),
+                        }
+                    ],
+                },
+            )
+        if path.endswith("/relations"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [
+                        {"classType": "ConceptRelation", "ui": "R{0}".format(page)}
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"result": {"classType": "Concept", "ui": "C0011849"}},
+        )
+
+    async with AsyncUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    ) as client:
+        profile = (await client.cui_api.get_concept_profile("C0011849")).result
+
+    assert [definition.value for definition in profile.definitions] == [
+        "Definition 1",
+        "Definition 2",
+    ]
+    assert [relation.ui for relation in profile.relations] == ["R1", "R2"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -6,7 +6,7 @@ import json
 import httpx
 import pytest
 
-from umls_python_client import UMLSClient, UMLSResponse
+from umls_python_client import TypedUMLSClient, UMLSClient, UMLSResponse
 
 
 def test_response_save_jsonl_csv_and_rdf(tmp_path) -> None:
@@ -58,3 +58,32 @@ def test_client_export_handles_existing_directory_with_suffix(tmp_path) -> None:
 
     assert output == directory / "umls_response.jsonl"
     assert json.loads(output.read_text())["product"] == "UMLS"
+
+
+def test_typed_response_export_uses_request_metadata_for_directory_paths(
+    tmp_path,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"result": {"results": [{"ui": "C1", "name": "Heart Attack"}]}},
+        )
+
+    with TypedUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    ) as client:
+        response = client.search_api.search("heart attack", page_size=1)
+        output = response.save(tmp_path, format="json")
+        exact_output = client.export(
+            response,
+            tmp_path / "exact-name.json",
+            format="json",
+        )
+
+    assert output.parent == tmp_path
+    assert output.name != "umls_response.json"
+    assert "search" in output.name
+    assert "heart_attack" in output.name
+    assert "secret" not in output.name
+    assert exact_output == tmp_path / "exact-name.json"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from contextlib import ExitStack
 
 import httpx
+import pytest
 
 from umls_python_client import ConceptProfile, TypedUMLSClient, UMLSClient
+from umls_python_client.errors import UMLSRequestError
 
 
 def test_auth_validation_constructs_uts_login_request(
@@ -70,12 +72,43 @@ def test_release_list_and_download_requests(
 
     assert releases["releaseTypes"][0]["product"] == "UMLS"
     assert typed_releases.result[0].product == "UMLS"
+    assert typed_releases.result[0].current is None
     assert typed_releases.result[0].url.endswith("umls-full-release")
     assert "apiKey" not in captured_requests[0].url.params
     assert "apiKey" not in captured_requests[1].url.params
     assert captured_requests[2].url.params["apiKey"] == "secret"
     assert captured_requests[2].url.params["url"].endswith("example.zip")
     assert output.read_bytes() == b"archive"
+
+
+def test_release_download_follows_redirects(
+    tmp_path,
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        if request.url.path == "/download":
+            return httpx.Response(
+                302,
+                headers={"location": "https://uts-ws.nlm.nih.gov/final.zip"},
+            )
+        return httpx.Response(200, content=b"redirected archive")
+
+    client = UMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    output = client.release_api.download_file(
+        "https://download.nlm.nih.gov/umls/kss/example.zip",
+        tmp_path,
+    )
+
+    assert [request.url.path for request in captured_requests] == [
+        "/download",
+        "/final.zip",
+    ]
+    assert output.read_bytes() == b"redirected archive"
 
 
 def test_typed_concept_profile_and_follow_url(
@@ -132,6 +165,155 @@ def test_typed_concept_profile_and_follow_url(
     assert profile.definitions[0].value == "Definition"
     assert followed.raw["result"]["ui"] == "C0011849"
     assert captured_requests[-1].url.params["apiKey"] == "secret"
+
+
+def test_follow_url_rejects_untrusted_hosts_before_request(
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, json={"result": []})
+
+    legacy_client = UMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+    typed_client = TypedUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    payload = legacy_client.follow_url(
+        "https://example.com/not-umls",
+        return_indented=False,
+    )
+
+    assert payload["error"] == "Request failed."
+    with pytest.raises(UMLSRequestError):
+        typed_client.follow_url("https://example.com/not-umls")
+    assert captured_requests == []
+
+
+def test_concept_profile_collects_all_documented_pages_by_default(
+    captured_requests: list[httpx.Request],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        path = request.url.path
+        if path.endswith("/atoms/preferred"):
+            return httpx.Response(
+                200,
+                json={"result": {"classType": "Atom", "ui": "A1", "name": "Diabetes"}},
+            )
+        if path.endswith("/definitions"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [
+                        {
+                            "classType": "Definition",
+                            "value": "Definition {0}".format(page),
+                        }
+                    ],
+                },
+            )
+        if path.endswith("/relations"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [
+                        {"classType": "ConceptRelation", "ui": "R{0}".format(page)}
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "result": {
+                    "classType": "Concept",
+                    "ui": "C0011849",
+                    "name": "Diabetes",
+                }
+            },
+        )
+
+    client = TypedUMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    profile = client.cui_api.get_concept_profile("C0011849").result
+    first_page_profile = client.cui_api.get_concept_profile(
+        "C0011849",
+        all_pages=False,
+    ).result
+
+    assert [definition.value for definition in profile.definitions] == [
+        "Definition 1",
+        "Definition 2",
+    ]
+    assert [relation.ui for relation in profile.relations] == ["R1", "R2"]
+    assert [definition.value for definition in first_page_profile.definitions] == [
+        "Definition 1"
+    ]
+
+
+def test_legacy_concept_profile_collects_all_documented_pages() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/atoms/preferred"):
+            return httpx.Response(
+                200,
+                json={"result": {"classType": "Atom", "ui": "A1", "name": "Diabetes"}},
+            )
+        if path.endswith("/definitions"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [{"classType": "Definition", "value": str(page)}],
+                },
+            )
+        if path.endswith("/relations"):
+            page = int(request.url.params["pageNumber"])
+            return httpx.Response(
+                200,
+                json={
+                    "pageNumber": page,
+                    "pageCount": 2,
+                    "result": [
+                        {
+                            "classType": "ConceptRelation",
+                            "ui": "R{0}".format(page),
+                        }
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={"result": {"classType": "Concept", "ui": "C0011849"}},
+        )
+
+    client = UMLSClient(
+        api_key="secret",
+        http_transport=httpx.MockTransport(handler),
+    )
+
+    profile = client.cui_api.get_concept_profile(
+        "C0011849",
+        return_indented=False,
+    )
+
+    assert [item["value"] for item in profile["result"]["definitions"]] == ["1", "2"]
+    assert [item["ui"] for item in profile["result"]["relations"]] == ["R1", "R2"]
 
 
 def test_bulk_helpers_metadata_lookup_and_paginated_iterator(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import httpx
 
-from umls_python_client import Concept, TypedUMLSClient, UMLSResponse, UnknownRecord
+from umls_python_client import (
+    Concept,
+    ReleaseInfo,
+    TypedUMLSClient,
+    UMLSResponse,
+    UnknownRecord,
+)
 from umls_python_client.models import model_for_class_type
 
 
@@ -38,6 +44,12 @@ def test_unknown_model_preserves_unknown_fields() -> None:
 
     assert isinstance(record, UnknownRecord)
     assert record.to_dict()["customField"] == "value"
+
+
+def test_release_info_current_preserves_unknown_state() -> None:
+    assert ReleaseInfo.from_dict({"releaseType": "UMLS"}).current is None
+    assert ReleaseInfo.from_dict({"current": True}).current is True
+    assert ReleaseInfo.from_dict({"current": "false"}).current is False
 
 
 def test_typed_client_raises_structured_errors() -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -26,6 +26,43 @@ def test_transport_injects_api_key_and_params() -> None:
     assert seen[0].url.params["string"] == "diabetes"
 
 
+def test_transport_allows_authenticated_umls_absolute_urls() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"result": {"ui": "C1"}})
+
+    transport = SyncUMLSTransport(
+        api_key="secret",
+        transport=httpx.MockTransport(handler),
+    )
+
+    transport.request(
+        absolute_url="https://uts-ws.nlm.nih.gov/rest/content/current/CUI/C1"
+    )
+
+    assert seen[0].url.params["apiKey"] == "secret"
+
+
+def test_transport_rejects_authenticated_untrusted_absolute_urls() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"result": []})
+
+    transport = SyncUMLSTransport(
+        api_key="secret",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(UMLSRequestError):
+        transport.request(absolute_url="https://example.com/steal")
+
+    assert seen == []
+
+
 def test_transport_retries_retryable_status() -> None:
     calls = 0
 


### PR DESCRIPTION
## Summary
- Prevent authenticated absolute URLs from leaking UMLS API keys to untrusted hosts.
- Make concept profiles fetch all documented definition and relation pages by default.
- Add request metadata to typed responses for safer generated export filenames.
- Preserve unknown release current state and follow redirects for release downloads.

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy src`
- `pytest`
- `mkdocs build --strict`
- `python -m build`

## Risk
Low. The changes are backward-compatible and focused on defect fixes. Legacy `follow_url()` still returns error payloads, while typed clients continue to raise structured exceptions.